### PR TITLE
fix(ci): skip windows-parity-smoke by default to remove misleading red X

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -149,7 +149,7 @@ jobs:
 
   windows-parity-smoke:
     needs: discover
-    if: needs.discover.outputs.has_services == 'true' && ((inputs.runner_target || 'auto') == 'self-hosted' || github.event_name != 'workflow_dispatch')
+    if: needs.discover.outputs.has_services == 'true' && (inputs.runner_target || 'auto') == 'self-hosted'
     runs-on: [self-hosted, Windows, X64, parity]
     continue-on-error: true
     steps:


### PR DESCRIPTION
## Problem

`windows-parity-smoke` ran on every push and PR event but always failed with exit code 1 because no self-hosted `[Windows, X64, parity]` runner is registered. Despite `continue-on-error: true`, GitHub still renders the job as a red ❌ in the workflow graph — visually indistinguishable from a real failure.

**Before:** push/PR → job runs → no runner → exit 1 → red ❌ in graph
**After:** push/PR → `if:` condition false → job skipped → clean graph

## Fix

Changed `if:` condition from:
```
(inputs.runner_target || 'auto') == 'self-hosted' || github.event_name != 'workflow_dispatch'
```
to:
```
(inputs.runner_target || 'auto') == 'self-hosted'
```

The job now only attempts to run when explicitly requested via `workflow_dispatch` with `runner_target: self-hosted`. On all other events (push, PR, schedule) it skips cleanly.

## Test plan
- [ ] CI graph on this PR shows no red X for `windows-parity-smoke`
- [ ] All other jobs unaffected