### PR TITLE
feat(ci): per-service Cosign signing + SBOM attest + SLSA provenance (Layer 1)

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -326,6 +326,86 @@ jobs:
           path: ${{ matrix.path }}/security-gate-findings.json
           if-no-files-found: warn
 
+      - name: Log in to GHCR
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image to GHCR
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+        run: docker push "${IMAGE}"
+
+      - name: Resolve image digest
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        id: digest
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+        run: |
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "value=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Cosign
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Sign image (keyless)
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.digest.outputs.value }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Attest SBOM (SPDX)
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.digest.outputs.value }}
+          SBOM_PATH: ${{ matrix.path }}/sbom.spdx.json
+        run: cosign attest --yes --predicate "${SBOM_PATH}" --type spdxjson "${IMAGE}@${DIGEST}"
+
+      - name: Build SLSA provenance predicate
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        env:
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          cat > "${{ matrix.path }}/provenance.json" <<EOF
+          {
+            "buildDefinition": {
+              "buildType": "https://github.com/actions/runner/v2",
+              "externalParameters": {
+                "workflow": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/ci-service.yml",
+                "ref": "${GITHUB_REF}",
+                "sha": "${GITHUB_SHA}"
+              }
+            },
+            "runDetails": {
+              "builder": {
+                "id": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              },
+              "metadata": {
+                "invocationId": "${GITHUB_RUN_ID}"
+              }
+            }
+          }
+          EOF
+
+      - name: Attest SLSA provenance
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.digest.outputs.value }}
+          PROV_PATH: ${{ matrix.path }}/provenance.json
+        run: cosign attest --yes --predicate "${PROV_PATH}" --type slsaprovenance1 "${IMAGE}@${DIGEST}"
+
   ci-summary:
     needs: [discover, verify-cross-os, supply-chain-ubuntu]
     if: always() && needs.discover.outputs.has_services == 'true'


### PR DESCRIPTION
## Goal (Layer 1 of high-scalability roadmap)

Every one of 23 images in GHCR should carry full supply chain artifacts:
- Cosign keyless signature
- SBOM attestation (SPDX)
- SLSA L1+ provenance attestation

## What changed

Added 8 new steps to `supply-chain-ubuntu` job, gated on `github.event_name == 'push' || github.event_name == 'schedule'`:

1. `docker/login-action` — log in to GHCR via GITHUB_TOKEN
2. `docker push` — push image to GHCR (already built locally for SBOM/scan)
3. Resolve registry digest via `docker buildx imagetools inspect`
4. `sigstore/cosign-installer@v3.7.0`
5. `cosign sign --yes ...` — keyless signing (OIDC token from GHA)
6. `cosign attest --predicate sbom.spdx.json --type spdxjson ...` — SBOM attestation
7. Build SLSA provenance predicate JSON (build environment, workflow ref, run ID)
8. `cosign attest --predicate provenance.json --type slsaprovenance1 ...` — provenance attestation

## PR vs main behavior

| Event | Build | SBOM | CVE scan | Push | Sign | SBOM attest | SLSA attest |
|-------|-------|------|----------|------|------|-------------|-------------|
| `pull_request` | yes | yes | yes | NO | NO | NO | NO |
| `push` (main) | yes | yes | yes | YES | YES | YES | YES |
| `schedule` | yes | yes | yes | YES | YES | YES | YES |

PR runs stay fast (build + scan only).

## Coverage after merge

23/23 services × {signature + SBOM attest + provenance attest} = 69 evidence artifacts published to GHCR.

## Test plan
- [ ] PR CI: 23 services pass without signing (no push)
- [ ] After merge: main push CI signs all 23 images
- [ ] Verify: `cosign verify ghcr.io/sinhnguyen1411/stock-trading/user-service:<tag>` succeeds with keyless certificate identity matching the workflow