### PR TITLE
feat(layer-2a): per-service VALID_ALLOW admission test for 23 services

### DIFF
--- a/.github/workflows/service-scs-matrix-evidence.yml
+++ b/.github/workflows/service-scs-matrix-evidence.yml
@@ -1,4 +1,4 @@
-﻿name: onboarding-lab
+name: onboarding-lab
 
 on:
   workflow_dispatch:
@@ -7,20 +7,26 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   discover-services:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.matrix.outputs.result }}
+      sha_tag: ${{ steps.matrix.outputs.sha_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build onboarding matrix from services.yaml
         id: matrix
         shell: python
+        env:
+          GITHUB_SHA_VALUE: ${{ github.sha }}
         run: |
           import json
+          import os
           import re
           import yaml
 
@@ -33,18 +39,22 @@ jobs:
               short = re.sub(r"-service$", "", name)
               include.append({
                   "service_name": name,
-                  "namespace": f"{short}-trading",
+                  "image_path": service["image"],
+                  "namespace": f"stock-trading-{short}",
                   "cluster_name": f"{short}-evidence",
+                  "short": short,
               })
 
           result = {"include": include}
-          with open(__import__("os").environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+          sha_tag = os.environ.get("GITHUB_SHA_VALUE", "")[:12]
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
               f.write(f"result={json.dumps(result)}\n")
+              f.write(f"sha_tag={sha_tag}\n")
 
   onboarding-probe:
     needs: discover-services
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -60,50 +70,192 @@ jobs:
           cluster_name: ${{ matrix.cluster_name }}
           wait: 180s
 
-      - name: Bootstrap Kyverno and policies
+      - name: Bootstrap Kyverno + repo policies
         run: |
           chmod +x ./infra/scripts/devsecops_kind_bootstrap.sh
           KIND_CLUSTER_NAME=${{ matrix.cluster_name }} RESET_CLUSTER=false ./infra/scripts/devsecops_kind_bootstrap.sh
 
-      - name: Run onboarding probe
+      - name: Create test namespace and GHCR imagePullSecret
+        env:
+          NAMESPACE: ${{ matrix.namespace }}
+        run: |
+          kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create secret docker-registry ghcr-pull \
+            --docker-server=ghcr.io \
+            --docker-username=${{ github.actor }} \
+            --docker-password=${{ secrets.GITHUB_TOKEN }} \
+            -n "${NAMESPACE}"
+
+      - name: VALID_ALLOW probe
         id: probe
+        env:
+          SERVICE_NAME: ${{ matrix.service_name }}
+          IMAGE_PATH: ${{ matrix.image_path }}
+          NAMESPACE: ${{ matrix.namespace }}
+          SHA_TAG: ${{ needs.discover-services.outputs.sha_tag }}
         shell: bash
         run: |
-          set -euo pipefail
-          RUN_ID="gha-${{ matrix.service_name }}-${{ github.run_number }}"
-          EXPORT_DIR="demo/evidence/${RUN_ID}"
-          mkdir -p "${EXPORT_DIR}"
+          set +e
+          IMAGE="ghcr.io/${IMAGE_PATH}:${SHA_TAG}"
 
-          cat > "${EXPORT_DIR}/evidence-metadata.json" <<EOF
-          {
-            "workflow_key": "onboarding-lab",
-            "service_name": "${{ matrix.service_name }}",
-            "scenario": "policy-scope-compatibility",
-            "runner_os": "ubuntu-latest",
-            "run_id": "${RUN_ID}",
-            "sha": "${{ github.sha }}",
-            "verdict": "generated",
-            "evidence_paths": [
-              "${EXPORT_DIR}/service-onboarding-summary.md"
-            ]
-          }
+          cat > deploy-valid.yaml <<EOF
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: ${SERVICE_NAME}
+            namespace: ${NAMESPACE}
+            labels:
+              app.kubernetes.io/name: ${SERVICE_NAME}
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: ${SERVICE_NAME}
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: ${SERVICE_NAME}
+                annotations:
+                  security.grype.io/high_critical: "0"
+                  security.stock-trading.dev/sbom-digest: "sha256:placeholder-onboarding"
+              spec:
+                imagePullSecrets:
+                  - name: ghcr-pull
+                containers:
+                  - name: ${SERVICE_NAME}
+                    image: ${IMAGE}
+                    ports:
+                      - containerPort: 8080
           EOF
 
+          APPLY_OUTPUT=$(kubectl apply -f deploy-valid.yaml 2>&1)
+          APPLY_EXIT=$?
+          echo "===== kubectl apply output ====="
+          echo "$APPLY_OUTPUT"
+          echo "===== exit code: $APPLY_EXIT ====="
+
+          # Give the cluster a moment to surface admission events
+          sleep 8
+          EVENTS=$(kubectl -n "${NAMESPACE}" get events --field-selector type=Warning -o yaml 2>&1 || true)
+
+          if [ $APPLY_EXIT -eq 0 ] && ! echo "$EVENTS" | grep -q "denied"; then
+            VERDICT="ALLOW"
+            STATUS="PASS"
+          elif echo "$APPLY_OUTPUT $EVENTS" | grep -q "denied"; then
+            VERDICT="DENY"
+            STATUS="FAIL"
+          else
+            VERDICT="ERROR"
+            STATUS="FAIL"
+          fi
+
+          echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
+          echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Write evidence
+        if: always()
+        env:
+          SERVICE_NAME: ${{ matrix.service_name }}
+          NAMESPACE: ${{ matrix.namespace }}
+          VERDICT: ${{ steps.probe.outputs.verdict }}
+          STATUS: ${{ steps.probe.outputs.status }}
+          IMAGE: ${{ steps.probe.outputs.image }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          mkdir -p evidence
+          cat > evidence/onboarding-result.json <<EOF
           {
-            echo "# Service Onboarding Probe Summary"
-            echo
-            echo "- Service: ${{ matrix.service_name }}"
-            echo "- Namespace: ${{ matrix.namespace }}"
-            echo "- Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            echo "- Status: generated"
-          } > "${EXPORT_DIR}/service-onboarding-summary.md"
+            "workflow_key": "onboarding-lab",
+            "service_name": "${SERVICE_NAME}",
+            "scenario": "VALID_ALLOW",
+            "expected_verdict": "ALLOW",
+            "actual_verdict": "${VERDICT:-ERROR}",
+            "test_status": "${STATUS:-FAIL}",
+            "namespace": "${NAMESPACE}",
+            "image": "${IMAGE}",
+            "run_id": "${RUN_ID}",
+            "sha": "${SHA}"
+          }
+          EOF
+          cat evidence/onboarding-result.json
 
-          echo "path=${EXPORT_DIR}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload onboarding artifact
+      - name: Upload onboarding evidence
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: onboarding-lab-${{ matrix.service_name }}
-          path: ${{ steps.probe.outputs.path }}
-          if-no-files-found: error
+          path: evidence/
+          if-no-files-found: warn
 
+  onboarding-summary:
+    needs: [discover-services, onboarding-probe]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download all onboarding evidence
+        uses: actions/download-artifact@v4
+        with:
+          pattern: onboarding-lab-*
+          path: evidence/
+          merge-multiple: false
+        continue-on-error: true
+
+      - name: Aggregate onboarding results
+        shell: python
+        env:
+          MATRIX_JSON: ${{ needs.discover-services.outputs.matrix }}
+          SHA_TAG: ${{ needs.discover-services.outputs.sha_tag }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          import json
+          import os
+          from pathlib import Path
+
+          matrix = json.loads(os.environ.get("MATRIX_JSON", '{"include":[]}'))
+          services = matrix.get("include", [])
+          n = len(services)
+          ev_dir = Path("evidence")
+
+          rows = []
+          pass_count = 0
+          for svc in services:
+              name = svc["service_name"]
+              fpath = ev_dir / f"onboarding-lab-{name}" / "onboarding-result.json"
+              if fpath.exists():
+                  try:
+                      data = json.loads(fpath.read_text(encoding="utf-8"))
+                      verdict = data.get("actual_verdict", "MISSING")
+                      status = data.get("test_status", "MISSING")
+                  except Exception:
+                      verdict, status = "PARSE_ERROR", "FAIL"
+              else:
+                  verdict, status = "MISSING", "FAIL"
+
+              if status == "PASS":
+                  pass_count += 1
+              rows.append((name, verdict, status))
+
+          run_url = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          overall = "PASS" if pass_count == n else "FAIL"
+
+          lines = [
+              f"## {overall} - Onboarding Lab Summary - {pass_count}/{n} services",
+              "",
+              "Scenario: VALID_ALLOW (signed image from Layer 1 + valid annotations)",
+              f"Image tag: `{os.environ.get('SHA_TAG', 'unknown')}`",
+              "",
+              "| Service | Verdict | Status |",
+              "|---------|---------|--------|",
+          ]
+          for name, verdict, status in rows:
+              lines.append(f"| `{name}` | {verdict} | {status} |")
+
+          lines += ["", f"Run URL: {run_url}"]
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "w", encoding="utf-8") as f:
+              f.write("\n".join(lines))

--- a/infra/policies/kyverno/clusterpolicy-cve-threshold.yaml
+++ b/infra/policies/kyverno/clusterpolicy-cve-threshold.yaml
@@ -16,9 +16,8 @@ spec:
         any:
           - resources:
               kinds: ["Pod"]
-              selector:
-                matchLabels:
-                  app.kubernetes.io/name: user-service
+              namespaces:
+                - stock-trading-*
       validate:
         message: "Pod rejected: fixable High/Critical CVEs not cleared (security.grype.io/high_critical must be '0')."
         pattern:

--- a/infra/policies/kyverno/clusterpolicy-require-sbom.yaml
+++ b/infra/policies/kyverno/clusterpolicy-require-sbom.yaml
@@ -16,9 +16,8 @@ spec:
         any:
           - resources:
               kinds: ["Pod"]
-              selector:
-                matchLabels:
-                  app.kubernetes.io/name: user-service
+              namespaces:
+                - stock-trading-*
       validate:
         message: "Pod rejected: missing SBOM reference annotation (security.stock-trading.dev/sbom-digest)."
         pattern:

--- a/infra/policies/kyverno/clusterpolicy-verify-images.yaml
+++ b/infra/policies/kyverno/clusterpolicy-verify-images.yaml
@@ -26,7 +26,7 @@ spec:
             - count: 1
               entries:
                 - keyless:
-                    subject: "https://github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/.github/workflows/secure-supply-chain.yml@refs/heads/main"
+                    subject: "https://github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/.github/workflows/ci-service.yml@refs/heads/main"
                     issuer: "https://token.actions.githubusercontent.com"
                     rekor:
                       url: https://rekor.sigstore.dev
@@ -39,12 +39,12 @@ spec:
         - imageReferences:
             - "ghcr.io/sinhnguyen1411/stock-trading/*"
           attestations:
-            - type: https://slsa.dev/provenance/v0.2
+            - type: https://slsa.dev/provenance/v1
               attestors:
                 - count: 1
                   entries:
                     - keyless:
-                        subject: "https://github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/.github/workflows/secure-supply-chain.yml@refs/heads/main"
+                        subject: "https://github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/.github/workflows/ci-service.yml@refs/heads/main"
                         issuer: "https://token.actions.githubusercontent.com"
                         rekor:
                           url: https://rekor.sigstore.dev

--- a/infra/scripts/devsecops_kind_bootstrap.sh
+++ b/infra/scripts/devsecops_kind_bootstrap.sh
@@ -109,6 +109,36 @@ wait_for_kyverno
 kubectl -n kyverno wait --for=condition=Available deploy --all --timeout="${KYVERNO_ROLLOUT_TIMEOUT}"
 wait_for_kyverno_webhook
 
+# Webhook TCP probe: pod Ready != mutate webhook serving. Retry dry-run apply
+# of a minimal ClusterPolicy until any response other than "connection refused".
+probe_kyverno_webhook() {
+  local probe_yaml
+  probe_yaml="$(mktemp --suffix=.yaml)"
+  cat >"$probe_yaml" <<'YAML'
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: kyverno-webhook-probe
+spec:
+  rules: []
+YAML
+  local out
+  for i in $(seq 1 24); do
+    out="$(kubectl apply --dry-run=server -f "$probe_yaml" 2>&1 || true)"
+    if ! echo "$out" | grep -q "connection refused"; then
+      rm -f "$probe_yaml"
+      echo "Kyverno webhook is responding."
+      return 0
+    fi
+    echo "Kyverno webhook not ready yet (${i}/24), retrying in 5s..."
+    sleep 5
+  done
+  rm -f "$probe_yaml"
+  echo "Kyverno webhook did not respond within 120s." >&2
+  return 1
+}
+probe_kyverno_webhook
+
 echo "[3/4] Applying supply-chain policies"
 kubectl apply -k infra/policies/kyverno
 


### PR DESCRIPTION
## Goal (Layer 2a of high-scalability roadmap)

Refactor `onboarding-lab` from stub (writes markdown only) into a real admission probe that tests each of 23 services against the supply-chain Kyverno policies, using the signed images produced by Layer 1.

## Critical policy fixes

The Kyverno policies in `infra/policies/kyverno/` were stale and would have rejected every Layer 1 signed image:

| File | Before | After |
|------|--------|-------|
| `clusterpolicy-verify-images.yaml` | workflow identity `secure-supply-chain.yml@refs/heads/main` (does not exist) | `ci-service.yml@refs/heads/main` (matches actual signing workflow) |
| `clusterpolicy-verify-images.yaml` | SLSA attestation type `provenance/v0.2` | `provenance/v1` (matches cosign `--type slsaprovenance1`) |
| `clusterpolicy-cve-threshold.yaml` | matched only `app.kubernetes.io/name: user-service` | matches namespace pattern `stock-trading-*` |
| `clusterpolicy-require-sbom.yaml` | matched only `app.kubernetes.io/name: user-service` | matches namespace pattern `stock-trading-*` |

## Onboarding lab refactor

Per service (23 total, `max-parallel: 3`):
1. Set up dedicated Kind cluster `<short>-evidence`
2. Bootstrap Kyverno v1.12.5 + apply repo ClusterPolicies via existing `devsecops_kind_bootstrap.sh`
3. Create namespace `stock-trading-<short>` + GHCR imagePullSecret using `GITHUB_TOKEN`
4. Apply a Deployment with `ghcr.io/<image>:<sha>` (the Layer 1 signed image) + valid annotations (`security.grype.io/high_critical=0`, `security.stock-trading.dev/sbom-digest=...`)
5. Record verdict (`ALLOW`/`DENY`/`ERROR`) and status (`PASS`/`FAIL`)
6. Upload per-service evidence JSON

New `onboarding-summary` job aggregates all 23 results into a single consolidated table in the job summary.

## Expected outcome

After merge + next scheduled run (02:30 UTC) or `workflow_dispatch`:

```
PASS - Onboarding Lab Summary - 23/23 services

| Service             | Verdict | Status |
|---------------------|---------|--------|
| user-service        | ALLOW   | PASS   |
| portfolio-service   | ALLOW   | PASS   |
| ...                 | ALLOW   | PASS   |
```

## Out of scope (Layer 2b, separate PR)

Deny-side scenarios per service (NEG_UNSIGNED_DENY, NEG_MISSING_SBOM_DENY, NEG_CVE_THRESHOLD_DENY) will be added in Layer 2b once the VALID_ALLOW baseline is confirmed working across all 23 services.

## Test plan
- [ ] PR CI passes (no admission-lab impact)
- [ ] After merge, manually trigger `onboarding-lab` workflow
- [ ] All 23 services report `ALLOW` verdict and `PASS` status