### PR TITLE
fix(ci): unsigned-canary push survives partial supply-chain failure

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -408,7 +408,7 @@ jobs:
 
   push-unsigned-canary:
     needs: [discover, supply-chain-ubuntu]
-    if: needs.discover.outputs.has_services == 'true' && (github.event_name == 'push' || github.event_name == 'schedule')
+    if: always() && needs.discover.outputs.has_services == 'true' && (github.event_name == 'push' || github.event_name == 'schedule') && needs.supply-chain-ubuntu.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Problem

PR #25 merged → ci-service ran on main → `user-service` failed at `Push image to GHCR` (pre-existing GHCR package permission issue, same as before) → entire `supply-chain-ubuntu` matrix marked as failed (because `fail-fast: false` doesn't change the overall job result for `needs:` checks) → `push-unsigned-canary` got **skipped** → `onboarding-lab` would not be able to test `NEG_UNSIGNED_DENY` scenario.

## Fix

Change `push-unsigned-canary` job condition from:
```
if: needs.discover.outputs.has_services == 'true' && (github.event_name == 'push' || github.event_name == 'schedule')
```
to:
```
if: always() && needs.discover.outputs.has_services == 'true' && (github.event_name == 'push' || github.event_name == 'schedule') && needs.supply-chain-ubuntu.result != 'cancelled'
```

`always()` opts in to "run even if `needs` failed", and the explicit `!= 'cancelled'` check still skips when the supply-chain set was outright cancelled (sensible safety).

## Separate concern

`user-service` GHCR push needs a manual permission grant (link package to source repo with write access). That's tracked separately and is not blocking this fix.

## Test plan
- [ ] Merge -> next ci-service run on main pushes unsigned-canary regardless of user-service status