### PR TITLE
fix(ci): auto-recover from GHCR permission_denied on legacy packages

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -334,11 +334,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push image to GHCR
+      - name: Push image to GHCR (auto-recover on permission_denied)
         if: github.event_name == 'push' || github.event_name == 'schedule'
         env:
           IMAGE: ${{ steps.meta.outputs.image }}
-        run: docker push "${IMAGE}"
+          IMAGE_PATH: ${{ matrix.image }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set +e
+          OUT=$(docker push "${IMAGE}" 2>&1)
+          RC=$?
+          echo "$OUT"
+          if [ $RC -eq 0 ]; then exit 0; fi
+
+          if echo "$OUT" | grep -q "permission_denied: write_package"; then
+            echo ""
+            echo "===== Auto-recovery triggered ====="
+            echo "Permission denied on legacy GHCR package. Deleting + retrying..."
+            ENCODED=$(echo -n "$IMAGE_PATH" | sed 's|/|%2F|g')
+            DEL_HTTP=$(curl -sS -o /tmp/del-out -w "%{http_code}" -X DELETE \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/user/packages/container/$ENCODED")
+            echo "DELETE response: HTTP $DEL_HTTP"
+            cat /tmp/del-out 2>/dev/null || true
+            if [ "$DEL_HTTP" = "204" ] || [ "$DEL_HTTP" = "404" ]; then
+              sleep 5
+              docker push "${IMAGE}"
+              exit $?
+            else
+              echo "Could not delete package via API. Aborting."
+              echo "Manual fix: https://github.com/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${ENCODED}/settings -> Manage Actions access"
+              exit 1
+            fi
+          fi
+          exit $RC
 
       - name: Resolve image digest
         if: github.event_name == 'push' || github.event_name == 'schedule'


### PR DESCRIPTION
## Problem

The `user-service` GHCR package is legacy (predates the recent rename/restructure work). Its repository actions-access linkage is in a state where:
- Manual delete via Web UI works once → next workflow_dispatch push works
- But subsequent `push` event runs fail again with `denied: permission_denied: write_package`

Manual fixes don't persist. We need the workflow to handle this autonomously.

## Fix

Rewrite the **Push image to GHCR** step into a bash script that:

1. Tries `docker push "${IMAGE}"`
2. If RC=0 → done
3. If RC != 0 AND output contains `permission_denied: write_package`:
   - Call `DELETE /user/packages/container/<encoded-name>` using `GITHUB_TOKEN`
   - GITHUB_TOKEN with `packages: write` permission includes package deletion
   - If DELETE returns 204 (deleted) or 404 (already gone) → wait 5s → retry docker push
   - Else → print manual-fix URL and exit 1

For 22/23 services this path is never taken (push succeeds first try). For `user-service` the auto-delete + retry makes the push succeed without user intervention.

## Test plan
- [ ] Merge → next ci-service run on main: user-service auto-recovers, all 23 packages pushed + signed