### PR TITLE
fix(onboarding-lab): YAML indent on sbom-digest annotation caused 71/92 ERROR

### DIFF
--- a/.github/workflows/service-scs-matrix-evidence.yml
+++ b/.github/workflows/service-scs-matrix-evidence.yml
@@ -101,14 +101,12 @@ jobs:
           SIGNED_IMAGE="ghcr.io/${IMAGE_PATH}:${SHA_TAG}"
           UNSIGNED_IMAGE="ghcr.io/sinhnguyen1411/stock-trading/unsigned-canary:latest"
 
-          # Helper: render a Deployment YAML
+          # Helper: render a Deployment YAML. SBOM annotation is always rendered
+          # with a marker; if anno_sbom is empty we strip the line via sed.
           render_deploy() {
             local name="$1" image="$2" anno_cve="$3" anno_sbom="$4"
-            local sbom_line=""
-            if [ -n "$anno_sbom" ]; then
-              sbom_line="                  security.stock-trading.dev/sbom-digest: \"${anno_sbom}\""
-            fi
-            cat <<EOF
+            local sbom_value="${anno_sbom:-__SBOM_OMIT__}"
+            cat <<EOF | { if [ "$sbom_value" = "__SBOM_OMIT__" ]; then sed '/security.stock-trading.dev\/sbom-digest/d'; else cat; fi; }
           apiVersion: apps/v1
           kind: Deployment
           metadata:
@@ -127,7 +125,7 @@ jobs:
                   app.kubernetes.io/name: ${name}
                 annotations:
                   security.grype.io/high_critical: "${anno_cve}"
-          ${sbom_line}
+                  security.stock-trading.dev/sbom-digest: "${sbom_value}"
               spec:
                 imagePullSecrets:
                   - name: ghcr-pull


### PR DESCRIPTION
## Root cause

PR #25 rendered Deployment YAMLs via a bash heredoc. The SBOM annotation line was injected via a `\${sbom_line}` variable that carried 18 leading spaces inside its value. After GitHub Actions stripped the 10-space run-block prefix from the script, the rendered YAML had:

- `security.grype.io/high_critical` at column 8 (correct indent under `annotations:`)
- `security.stock-trading.dev/sbom-digest` at column 18 (out of context)

Result: `kubectl apply` errored on the malformed YAML before admission webhooks ever ran. 3 of 4 scenarios per service returned `ERROR` instead of an admission verdict.

Real numbers from run 26146683911:
- `VALID_ALLOW`: 0/23 PASS (all ERROR)
- `NEG_MISSING_SBOM_DENY`: 21/23 PASS (works because the line is omitted)
- `NEG_CVE_THRESHOLD_DENY`: 0/23 PASS (all ERROR)
- `NEG_UNSIGNED_DENY`: 0/23 PASS (all ERROR)
- Overall: 21/92 admission tests passed

## Fix

Render `sbom-digest` annotation inline alongside `high_critical` with consistent indent. For scenarios that need the annotation omitted (NEG_MISSING_SBOM_DENY), pipe the rendered YAML through `sed '/security.stock-trading.dev/sbom-digest/d'`.

This removes the variable-substitution indent mismatch entirely.

## Test plan
- [ ] Merge -> trigger onboarding-lab -> expect 92/92 admission tests PASS (or close to it; user-service may still have GHCR push issue tracked in PR #27)