### PR TITLE
fix: rename user-service GHCR path to escape stuck legacy metadata

### DIFF
--- a/docs/go_microservice_onboarding_guide.md
+++ b/docs/go_microservice_onboarding_guide.md
@@ -13,7 +13,7 @@ For a new service, define and version these values first:
 | Parameter | Example in current repo | New service value |
 |---|---|---|
 | Go module path | `github.com/sinhnguyen1411/stock-trading-be/services/user-service` | `<your-module-path>` |
-| Image repository | `ghcr.io/sinhnguyen1411/stock-trading/user-service` | `<registry>/<org>/<service>` |
+| Image repository | `ghcr.io/sinhnguyen1411/stock-trading-app/user-service` | `<registry>/<org>/<service>` |
 | Kubernetes app label | `app.kubernetes.io/name=user-service` | `<service-app-label>` |
 | Namespace | `stock-trading` | `<service-namespace>` |
 | Runtime config secret keys | `auth-access-token-secret`, `auth-refresh-token-secret` | `<service-secret-keys>` |

--- a/infra/policies/kyverno/clusterpolicy-verify-images.yaml
+++ b/infra/policies/kyverno/clusterpolicy-verify-images.yaml
@@ -22,6 +22,7 @@ spec:
       verifyImages:
         - imageReferences:
             - "ghcr.io/sinhnguyen1411/stock-trading/*"
+            - "ghcr.io/sinhnguyen1411/stock-trading-app/*"
           attestors:
             - count: 1
               entries:
@@ -38,6 +39,7 @@ spec:
       verifyImages:
         - imageReferences:
             - "ghcr.io/sinhnguyen1411/stock-trading/*"
+            - "ghcr.io/sinhnguyen1411/stock-trading-app/*"
           attestations:
             - type: https://slsa.dev/provenance/v1
               attestors:

--- a/services.yaml
+++ b/services.yaml
@@ -1,7 +1,7 @@
 services:
   - name: user-service
     path: services/user-service
-    image: sinhnguyen1411/stock-trading/user-service
+    image: sinhnguyen1411/stock-trading-app/user-service
     go_version: "1.25.10"
     profile_tags: ["http-api", "db-migration"]
   - name: portfolio-service

--- a/services/user-service/deploy/kubernetes/base/deployment.yaml
+++ b/services/user-service/deploy/kubernetes/base/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: user-service
-          image: ghcr.io/sinhnguyen1411/stock-trading/user-service:dev
+          image: ghcr.io/sinhnguyen1411/stock-trading-app/user-service:dev
           imagePullPolicy: IfNotPresent
           args:
             - server


### PR DESCRIPTION
## Problem confirmed

PR #27's auto-recovery (`DELETE package -> retry push`) ran on ci-service run #81 with user-service. The log showed:

```
denied: permission_denied: write_package
===== Auto-recovery triggered =====
DELETE response: HTTP 404
{"message": "Package not found.", ...}
denied: permission_denied: write_package   <- retry still failed
```

GitHub's API says the package does NOT exist (404), but `docker push` still hits `permission_denied`. There is **stuck metadata in the `ghcr.io/sinhnguyen1411/stock-trading/user-service` namespace** that we cannot clear via API.

## Fix: rename the image path

Move user-service from `stock-trading/user-service` to `stock-trading-app/user-service`. The new path has no GitHub package history -> first push creates a fresh package with the workflow as publisher and the source repo automatically linked for actions access.

| File | Change |
|------|--------|
| `services.yaml` | user-service `image` -> `sinhnguyen1411/stock-trading-app/user-service` |
| `services/user-service/deploy/kubernetes/base/deployment.yaml` | container `image:` -> new path |
| `infra/policies/kyverno/clusterpolicy-verify-images.yaml` | add new path to `imageReferences` glob alongside the existing one |
| `docs/go_microservice_onboarding_guide.md` | example URL aligned |

The 22 other services keep their existing `stock-trading/*` path - this is targeted at the one package with broken legacy metadata.

## Cleanup follow-up

PR #27's auto-recovery code stays in place as a safety net for future legacy-package incidents, but should never trigger now that user-service uses a fresh path.

## Test plan
- [ ] Merge -> next ci-service run on main pushes user-service to the new path
- [ ] Trigger onboarding-lab -> expect 92/92 admission tests (combined with PR #28 indent fix already merged)