### PR TITLE
feat(layer-3): NEG_WRONG_KEY_DENY + NEG_MISSING_PROVENANCE_DENY advanced attack scenarios

### DIFF
--- a/.github/workflows/admission-matrix-evidence.yml
+++ b/.github/workflows/admission-matrix-evidence.yml
@@ -94,6 +94,8 @@ jobs:
             ${{ steps.run_dir.outputs.path }}/NEG_UNSIGNED_DENY
             ${{ steps.run_dir.outputs.path }}/NEG_MISSING_SBOM_DENY
             ${{ steps.run_dir.outputs.path }}/NEG_CVE_THRESHOLD_DENY
+            ${{ steps.run_dir.outputs.path }}/NEG_WRONG_KEY_DENY
+            ${{ steps.run_dir.outputs.path }}/NEG_MISSING_PROVENANCE_DENY
             ${{ steps.run_dir.outputs.path }}/VALID_ALLOW_RECHECK
           if-no-files-found: error
 

--- a/infra/scripts/admission_matrix_demo.ps1
+++ b/infra/scripts/admission_matrix_demo.ps1
@@ -397,6 +397,36 @@ if (-not $unsignedDigest) { throw "Unable to resolve unsigned image digest." }
 Write-Host "Signed digest  : $signedDigest"
 Write-Host "Unsigned digest: $unsignedDigest"
 
+Write-Section "Prepare Wrong-Key And No-Provenance Image Variants (Layer 3 advanced)"
+$wrongKeyImage = New-DemoImageRef -namePrefix "stock-trading-matrix-wrong-key" -ttl $ImageTtl
+$noProvImage = New-DemoImageRef -namePrefix "stock-trading-matrix-no-prov" -ttl $ImageTtl
+
+& docker tag $localImage $wrongKeyImage
+if ($LASTEXITCODE -ne 0) { throw "docker tag wrong-key image failed." }
+& docker push $wrongKeyImage
+if ($LASTEXITCODE -ne 0) { throw "docker push wrong-key image failed." }
+
+& docker tag $localImage $noProvImage
+if ($LASTEXITCODE -ne 0) { throw "docker tag no-provenance image failed." }
+& docker push $noProvImage
+if ($LASTEXITCODE -ne 0) { throw "docker push no-provenance image failed." }
+
+$wrongKeyRepo = $wrongKeyImage.Split(":")[0]
+$noProvRepo = $noProvImage.Split(":")[0]
+
+$wrongKeyRepoDigests = & docker inspect --format='{{range .RepoDigests}}{{println .}}{{end}}' $wrongKeyImage
+if ($LASTEXITCODE -ne 0) { throw "docker inspect wrong-key image failed." }
+$wrongKeyDigest = (($wrongKeyRepoDigests -split "`r?`n") | Where-Object { $_ -like "$wrongKeyRepo@*" } | Select-Object -First 1).Trim()
+if (-not $wrongKeyDigest) { throw "Unable to resolve wrong-key image digest." }
+
+$noProvRepoDigests = & docker inspect --format='{{range .RepoDigests}}{{println .}}{{end}}' $noProvImage
+if ($LASTEXITCODE -ne 0) { throw "docker inspect no-provenance image failed." }
+$noProvDigest = (($noProvRepoDigests -split "`r?`n") | Where-Object { $_ -like "$noProvRepo@*" } | Select-Object -First 1).Trim()
+if (-not $noProvDigest) { throw "Unable to resolve no-provenance image digest." }
+
+Write-Host "Wrong-key digest    : $wrongKeyDigest"
+Write-Host "No-provenance digest: $noProvDigest"
+
 Write-Section "Generate SBOM + Sign + Attest (Signed Image Only)"
 $env:COSIGN_PASSWORD = $CosignPassword
 if (!(Test-Path $cosignKeyPath) -or !(Test-Path $cosignPubPath)) {
@@ -430,6 +460,29 @@ if ($LASTEXITCODE -ne 0) { throw "cosign attest failed." }
 if ($LASTEXITCODE -ne 0) { throw "cosign verify failed." }
 & cosign verify-attestation --key $cosignPubPath --type slsaprovenance $signedDigest | Out-Null
 if ($LASTEXITCODE -ne 0) { throw "cosign verify-attestation failed." }
+
+Write-Section "Sign Advanced-Attack Image Variants (Layer 3)"
+# (a) NEG_WRONG_KEY_DENY: sign the wrong-key image with an ephemeral KEY B (different
+#     from the trusted key A). The policy verifies with key A's public key, so the
+#     signature from key B fails verification.
+$wrongKeyDir = Join-Path $DemoArtifactsDir "wrong-key"
+Ensure-Directory $wrongKeyDir
+$wrongKeyPath = Join-Path $wrongKeyDir "cosign.key"
+$wrongPubPath = Join-Path $wrongKeyDir "cosign.pub"
+if (!(Test-Path $wrongKeyPath) -or !(Test-Path $wrongPubPath)) {
+  & cosign generate-key-pair --output-key-prefix ($wrongKeyPath -replace '\.key$', '')
+  if ($LASTEXITCODE -ne 0) { throw "wrong-key cosign key generation failed." }
+}
+& cosign sign --yes --key $wrongKeyPath $wrongKeyDigest
+if ($LASTEXITCODE -ne 0) { throw "cosign sign (wrong-key image) failed." }
+& cosign attest --yes --key $wrongKeyPath --predicate $provenancePath --type slsaprovenance $wrongKeyDigest
+if ($LASTEXITCODE -ne 0) { throw "cosign attest (wrong-key image) failed." }
+
+# (b) NEG_MISSING_PROVENANCE_DENY: sign the no-provenance image with the TRUSTED key A
+#     so the image-signature check passes, but skip the SLSA attestation. The policy
+#     requires a slsaprovenance attestation, so verification fails on attestation lookup.
+& cosign sign --yes --key $cosignKeyPath $noProvDigest
+if ($LASTEXITCODE -ne 0) { throw "cosign sign (no-provenance image) failed." }
 
 Write-Section "Ensure Kyverno"
 $hasClusterPolicyApi = & kubectl api-resources | Select-String -Pattern "^clusterpolicies\s"
@@ -487,6 +540,8 @@ spec:
         - imageReferences:
             - "$signedRepo*"
             - "$unsignedRepo*"
+            - "$wrongKeyRepo*"
+            - "$noProvRepo*"
           attestors:
             - entries:
                 - keys:
@@ -647,6 +702,20 @@ $cases = @(
     Image = $signedDigest
     IncludeSbom = $true
     HighCritical = "2"
+  },
+  [ordered]@{
+    Name = "NEG_WRONG_KEY_DENY"
+    Expected = "Denied"
+    Image = $wrongKeyDigest
+    IncludeSbom = $true
+    HighCritical = "0"
+  },
+  [ordered]@{
+    Name = "NEG_MISSING_PROVENANCE_DENY"
+    Expected = "Denied"
+    Image = $noProvDigest
+    IncludeSbom = $true
+    HighCritical = "0"
   }
 )
 


### PR DESCRIPTION
## Goal (Layer 3 of high-scalability roadmap, depth track)

Layer 2 demonstrated **breadth** (23/23 services x 4 basic scenarios = 92 admission tests). Layer 3 adds **depth** by exercising two advanced supply-chain attack vectors that the existing 4 base scenarios do not cover.

## What changed

### New image variants in `admission_matrix_demo.ps1`

Two ephemeral images pushed to `ttl.sh` alongside the existing signed/unsigned pair:

| Image variant | Signed by | SLSA attestation |
|---------------|-----------|------------------|
| `stock-trading-matrix-wrong-key-*` | Ephemeral key B (NOT the trusted key A) | yes (also signed by B) |
| `stock-trading-matrix-no-prov-*` | Trusted key A | no |

### New cases in the admission matrix

| Case | Demonstrates | Expected verdict |
|------|--------------|------------------|
| `NEG_WRONG_KEY_DENY` | Untrusted signer (e.g. compromised CI key, malicious fork) | Denied |
| `NEG_MISSING_PROVENANCE_DENY` | Missing SLSA L1+ build attestation | Denied |

The inline Kyverno policy's `imageReferences` glob also matches the two new repos, so the existing `verifyImages` rule (key A public key + slsaprovenance attestation type) applies uniformly.

### Test matrix layout after this PR

| # | Case | Notes |
|---|------|-------|
| 1 | VALID_ALLOW | Positive |
| 2 | NEG_UNSIGNED_DENY | Base (existing) |
| 3 | NEG_MISSING_SBOM_DENY | Base (existing) |
| 4 | NEG_CVE_THRESHOLD_DENY | Base (existing) |
| 5 | **NEG_WRONG_KEY_DENY** | Advanced (new) |
| 6 | **NEG_MISSING_PROVENANCE_DENY** | Advanced (new) |
| 7 | VALID_ALLOW_RECHECK | Regression |

## Thesis narrative coverage

| Layer | Track | Coverage |
|-------|-------|----------|
| 1 | Artifact | 23/23 images signed + SBOM + SLSA attest |
| 2 | Breadth | 91/92 admission tests across 23 services x 4 scenarios |
| 3 | Depth | 6 attack vectors covered on user-service (+ 1 regression) |

## Test plan
- [ ] Merge -> next scheduled admission-lab (02:00 UTC) or manual workflow_dispatch
- [ ] Confirm all 6 cases plus regression complete with expected verdicts