### PR TITLE
fix(layer-3): use $DemoDir not $DemoArtifactsDir (PR #30 typo)

### DIFF
--- a/infra/scripts/admission_matrix_demo.ps1
+++ b/infra/scripts/admission_matrix_demo.ps1
@@ -465,7 +465,7 @@ Write-Section "Sign Advanced-Attack Image Variants (Layer 3)"
 # (a) NEG_WRONG_KEY_DENY: sign the wrong-key image with an ephemeral KEY B (different
 #     from the trusted key A). The policy verifies with key A's public key, so the
 #     signature from key B fails verification.
-$wrongKeyDir = Join-Path $DemoArtifactsDir "wrong-key"
+$wrongKeyDir = Join-Path $DemoDir "wrong-key"
 Ensure-Directory $wrongKeyDir
 $wrongKeyPath = Join-Path $wrongKeyDir "cosign.key"
 $wrongPubPath = Join-Path $wrongKeyDir "cosign.pub"


### PR DESCRIPTION
PR #30 introduced $DemoArtifactsDir which is not defined. PowerShell strict mode threw on line 468. Replace with $DemoDir (the correct variable used everywhere else in this script). One-line fix.