### PR TITLE
feat(slsa): add official SLSA Build L3 attestation for user-service

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -437,6 +437,87 @@ jobs:
           PROV_PATH: ${{ matrix.path }}/provenance.json
         run: cosign attest --yes --predicate "${PROV_PATH}" --type slsaprovenance1 "${IMAGE}@${DIGEST}"
 
+      # --- SLSA Build L3 attestation (flagship: user-service only) ---
+      # Save image + digest as artifact so a downstream job can pipe them
+      # into the official slsa-github-generator reusable workflow.
+      - name: Save user-service digest for SLSA L3 attestation
+        if: matrix.short_name == 'user' && (github.event_name == 'push' || github.event_name == 'schedule')
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          DIGEST: ${{ steps.digest.outputs.value }}
+        run: |
+          mkdir -p /tmp/slsa-l3
+          # Strip :tag from image, keep only the repository path
+          echo "${IMAGE%%:*}" > /tmp/slsa-l3/image.txt
+          echo "${DIGEST}" > /tmp/slsa-l3/digest.txt
+
+      - name: Upload digest artifact for SLSA L3 job
+        if: matrix.short_name == 'user' && (github.event_name == 'push' || github.event_name == 'schedule')
+        uses: actions/upload-artifact@v4
+        with:
+          name: user-service-slsa-l3-digest
+          path: /tmp/slsa-l3/
+          retention-days: 1
+
+  # Read user-service digest from artifact and expose as job output so the
+  # slsa-github-generator reusable workflow (called below) can consume it.
+  read-user-slsa-digest:
+    needs: [discover, supply-chain-ubuntu]
+    if: |
+      always()
+      && needs.discover.outputs.has_services == 'true'
+      && (github.event_name == 'push' || github.event_name == 'schedule')
+      && needs.supply-chain-ubuntu.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      image: ${{ steps.read.outputs.image }}
+      digest: ${{ steps.read.outputs.digest }}
+      has_value: ${{ steps.read.outputs.has_value }}
+    steps:
+      - name: Download digest artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: user-service-slsa-l3-digest
+          path: /tmp/slsa-l3
+        continue-on-error: true
+      - name: Read image + digest
+        id: read
+        shell: bash
+        run: |
+          if [[ -f /tmp/slsa-l3/digest.txt && -f /tmp/slsa-l3/image.txt ]]; then
+            IMAGE="$(cat /tmp/slsa-l3/image.txt | tr -d '[:space:]')"
+            DIGEST="$(cat /tmp/slsa-l3/digest.txt | tr -d '[:space:]')"
+            if [[ -n "${IMAGE}" && -n "${DIGEST}" ]]; then
+              echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+              echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+              echo "has_value=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "has_value=false" >> "$GITHUB_OUTPUT"
+
+  # Official SLSA Build L3 attestation for user-service (flagship).
+  # Uses the OpenSSF reusable workflow which generates provenance inside an
+  # isolated builder job that the caller cannot tamper with -- this is the
+  # core property that distinguishes L3 from the custom L1+ attestation
+  # produced by `supply-chain-ubuntu` for all 23 services.
+  provenance-l3-user-service:
+    needs: [read-user-slsa-digest]
+    if: needs.read-user-slsa-digest.outputs.has_value == 'true'
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ${{ needs.read-user-slsa-digest.outputs.image }}
+      digest: ${{ needs.read-user-slsa-digest.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
   push-unsigned-canary:
     needs: [discover, supply-chain-ubuntu]
     if: always() && needs.discover.outputs.has_services == 'true' && (github.event_name == 'push' || github.event_name == 'schedule') && needs.supply-chain-ubuntu.result != 'cancelled'

--- a/infra/policies/kyverno/clusterpolicy-verify-images.yaml
+++ b/infra/policies/kyverno/clusterpolicy-verify-images.yaml
@@ -41,12 +41,24 @@ spec:
             - "ghcr.io/sinhnguyen1411/stock-trading/*"
             - "ghcr.io/sinhnguyen1411/stock-trading-app/*"
           attestations:
+            # Accept SLSA provenance signed by EITHER:
+            # (a) our ci-service.yml workflow -- L1 + L2-flavored (all 23 services)
+            # (b) the official OpenSSF slsa-github-generator reusable workflow -- L3
+            #     (currently produced for user-service flagship only)
+            # `count: 1` means at least one of the two attestor identities must match,
+            # so images that get L3 from (b) are accepted while older images attested
+            # only by (a) are still accepted.
             - type: https://slsa.dev/provenance/v1
               attestors:
                 - count: 1
                   entries:
                     - keyless:
                         subject: "https://github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/.github/workflows/ci-service.yml@refs/heads/main"
+                        issuer: "https://token.actions.githubusercontent.com"
+                        rekor:
+                          url: https://rekor.sigstore.dev
+                    - keyless:
+                        subject: "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v2.0.0"
                         issuer: "https://token.actions.githubusercontent.com"
                         rekor:
                           url: https://rekor.sigstore.dev


### PR DESCRIPTION
## Summary
- Integrate the OpenSSF [`slsa-github-generator/generator_container_slsa3.yml@v2.0.0`](https://github.com/slsa-framework/slsa-github-generator) reusable workflow to produce **official SLSA Build L3** provenance for the `user-service` flagship image.
- The generator runs in an isolated builder that the caller workflow cannot tamper with -- the core property that distinguishes L3 from the custom L1+L2-flavored attestation already produced by `supply-chain-ubuntu` for all 23 services.
- Track A (custom keyless via `ci-service.yml`) **kept for all 23 services**; Track B (generator) **added for `user-service` only** (matrix fan-out for the other 22 services is future work).
- Kyverno `verify-stock-trading-images` updated: SLSA attestation rule now accepts **either** attestor identity (`count: 1` with two keyless entries) -- backward-compatible with all existing 22 services.

## File changes (+93 lines, 2 files)
- `.github/workflows/ci-service.yml` (+81)
  - `supply-chain-ubuntu`: new steps to save user-service image+digest as artifact
  - new job `read-user-slsa-digest`: reads digest artifact, exposes job outputs
  - new job `provenance-l3-user-service`: calls `generator_container_slsa3.yml@v2.0.0`
- `infra/policies/kyverno/clusterpolicy-verify-images.yaml` (+12)
  - `verify-keyless-slsa-attestation`: two attestor identities (ci-service.yml OR generator workflow)

## Test plan
- [x] Validate ci-service.yml YAML syntax (local: `python -c \"import yaml; yaml.safe_load(...)\"` -- OK)
- [x] Validate clusterpolicy YAML syntax (local: OK)
- [ ] After merge: trigger workflow_dispatch with `service=user-service`, confirm `provenance-l3-user-service` job runs and succeeds
- [ ] Verify two SLSA Provenance attestations exist on the GHCR image (one per attestor identity): \`cosign tree ghcr.io/.../user-service@sha256:...\` should list 1 SBOM + 2 SLSA provenance attestations
- [ ] Run `admission-matrix-evidence.yml` after merge -- confirm all 7 Layer 3 scenarios still PASS with the updated Kyverno policy
- [ ] Run `service-scs-matrix-evidence.yml` (onboarding-lab) -- confirm `user-service` continues to pass `VALID_ALLOW` and the other 22 services unchanged (each still matches the existing Track A attestor)

## Notes
- Generator tag pinned to `@v2.0.0` (also used in Kyverno policy). Bumping the tag requires updating the policy subject string.
- L3 expansion to remaining 22 services requires a digest-aggregator job pattern (each matrix item uploads an artifact named per service; one job reads all, then 23 reusable workflow calls fan out). Documented as future work in chapter 5 of the thesis.