### PR TITLE
fix(ci): allow workflow_dispatch to trigger L1/L2/L3 attestation

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -327,7 +327,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Log in to GHCR
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -335,7 +335,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image to GHCR (auto-recover on permission_denied)
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           IMAGE: ${{ steps.meta.outputs.image }}
           IMAGE_PATH: ${{ matrix.image }}
@@ -372,7 +372,7 @@ jobs:
           exit $RC
 
       - name: Resolve image digest
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         id: digest
         env:
           IMAGE: ${{ steps.meta.outputs.image }}
@@ -381,18 +381,18 @@ jobs:
           echo "value=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Install Cosign
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: sigstore/cosign-installer@v3.7.0
 
       - name: Sign image (keyless)
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           IMAGE: ${{ steps.meta.outputs.image }}
           DIGEST: ${{ steps.digest.outputs.value }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
       - name: Attest SBOM (SPDX)
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           IMAGE: ${{ steps.meta.outputs.image }}
           DIGEST: ${{ steps.digest.outputs.value }}
@@ -400,7 +400,7 @@ jobs:
         run: cosign attest --yes --predicate "${SBOM_PATH}" --type spdxjson "${IMAGE}@${DIGEST}"
 
       - name: Build SLSA provenance predicate
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -430,7 +430,7 @@ jobs:
           EOF
 
       - name: Attest SLSA provenance
-        if: github.event_name == 'push' || github.event_name == 'schedule'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           IMAGE: ${{ steps.meta.outputs.image }}
           DIGEST: ${{ steps.digest.outputs.value }}
@@ -441,7 +441,7 @@ jobs:
       # Save image + digest as artifact so a downstream job can pipe them
       # into the official slsa-github-generator reusable workflow.
       - name: Save user-service digest for SLSA L3 attestation
-        if: matrix.name == 'user-service' && (github.event_name == 'push' || github.event_name == 'schedule')
+        if: matrix.name == 'user-service' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         env:
           IMAGE: ${{ steps.meta.outputs.image }}
           DIGEST: ${{ steps.digest.outputs.value }}
@@ -452,7 +452,7 @@ jobs:
           echo "${DIGEST}" > /tmp/slsa-l3/digest.txt
 
       - name: Upload digest artifact for SLSA L3 job
-        if: matrix.name == 'user-service' && (github.event_name == 'push' || github.event_name == 'schedule')
+        if: matrix.name == 'user-service' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:
           name: user-service-slsa-l3-digest
@@ -466,7 +466,7 @@ jobs:
     if: |
       always()
       && needs.discover.outputs.has_services == 'true'
-      && (github.event_name == 'push' || github.event_name == 'schedule')
+      && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       && needs.supply-chain-ubuntu.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 3
@@ -599,7 +599,7 @@ jobs:
 
   push-unsigned-canary:
     needs: [discover, supply-chain-ubuntu]
-    if: always() && needs.discover.outputs.has_services == 'true' && (github.event_name == 'push' || github.event_name == 'schedule') && needs.supply-chain-ubuntu.result != 'cancelled'
+    if: always() && needs.discover.outputs.has_services == 'true' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.supply-chain-ubuntu.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Summary

Single-line repeated fix: extend the event gate on attestation steps from \`push || schedule\` to \`push || schedule || workflow_dispatch\`. This unblocks manual demo runs needed to capture L3 evidence for the thesis without waiting for the next scheduled nightly run.

## Why

After merging PR #32 (L3 attestation infrastructure) and PR #33 (slsa-verifier), the workflow_dispatch run #26219024924 was triggered to capture evidence -- but the L3 jobs (\`provenance-l3-user-service\`, \`verify-slsa-l3-user-service\`) were all silently skipped because their upstream conditions excluded workflow_dispatch.

## Changes

12 lines changed across 6 conditions in \`.github/workflows/ci-service.yml\`:
- Sign image (keyless)
- Attest SBOM (SPDX)
- Build SLSA provenance predicate
- Attest SLSA provenance
- Save user-service digest for SLSA L3 attestation
- Upload digest artifact for SLSA L3 job
- read-user-slsa-digest job

Each now matches: \`github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'\`.

## Test plan

After merge:
- [ ] Trigger \`gh workflow run ci-service.yml -f service=user-service\`
- [ ] Verify the 5 attestation steps in \`supply-chain-ubuntu\` and the 3 L3 jobs all complete (not skipped)
- [ ] Check \`verify-slsa-l3-user-service\` Step Summary shows PASS