### PR TITLE
perf(ci): bump max-parallel for public-repo unlimited concurrency

### DIFF
--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -188,7 +188,9 @@ jobs:
     timeout-minutes: 25
     strategy:
       fail-fast: false
-      max-parallel: 6
+      # Repo is public -> no concurrent-job cap. 12 keeps build cache hot
+      # without saturating Docker layer locks on a single host.
+      max-parallel: 12
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     permissions:
       contents: read

--- a/.github/workflows/service-scs-matrix-evidence.yml
+++ b/.github/workflows/service-scs-matrix-evidence.yml
@@ -57,7 +57,11 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      max-parallel: 3
+      # Repo is public -> no concurrent-job cap, so we can run more onboarding
+      # clusters in parallel. 8 keeps Kind/Docker memory usage reasonable on
+      # ubuntu-latest runners (each cluster needs ~2 GB) while cutting wall
+      # time from ~8 batches (~40 min) to ~3 batches (~15 min) for 23 services.
+      max-parallel: 8
       matrix: ${{ fromJson(needs.discover-services.outputs.matrix) }}
 
     steps:


### PR DESCRIPTION
## Summary

Bump `max-parallel` on two matrix jobs to take advantage of the fact that this repo is public (no GitHub Actions concurrency cap):

| Workflow / Job | Before | After | Expected wall-time impact |
|---|---|---|---|
| `service-scs-matrix-evidence` / `onboarding-probe` | 3 | **8** | 23 services / 3 → 23 / 8: ~40 min → ~15 min |
| `ci-service` / `supply-chain-ubuntu` | 6 | **12** | 23 services / 6 → 23 / 12: ~14 min → ~7 min |

`verify-cross-os` stays at 8 — already balanced for the 23×2=46 cross-OS matrix.

## Why now

We're collecting fresh metrics for the thesis (Chapter 4: "Hệ thống thu thập bằng chứng tự động") and faster nightly runs make iteration tighter. The 3-cluster limit was carried over from when the repo was private; current public status lifts that constraint.

## Test plan

- [ ] After merge, trigger `service-scs-matrix-evidence.yml` via workflow_dispatch
- [ ] Confirm 23 onboarding-probe jobs run in batches of 8 (visible in the run graph)
- [ ] Verify total run time drops to ~15 min
- [ ] Trigger `ci-service.yml`, confirm supply-chain-ubuntu batches of 12 and total ~7 min