### PR TITLE
fix(kyverno): cover both admission-lab and onboarding-lab namespaces

### DIFF
--- a/infra/policies/kyverno/clusterpolicy-cve-threshold.yaml
+++ b/infra/policies/kyverno/clusterpolicy-cve-threshold.yaml
@@ -17,7 +17,8 @@ spec:
           - resources:
               kinds: ["Pod"]
               namespaces:
-                - stock-trading-*
+                - stock-trading        # admission-lab (single-cluster deep tests)
+                - stock-trading-*      # onboarding-lab (per-service clusters)
       validate:
         message: "Pod rejected: fixable High/Critical CVEs not cleared (security.grype.io/high_critical must be '0')."
         pattern:

--- a/infra/policies/kyverno/clusterpolicy-require-sbom.yaml
+++ b/infra/policies/kyverno/clusterpolicy-require-sbom.yaml
@@ -17,7 +17,8 @@ spec:
           - resources:
               kinds: ["Pod"]
               namespaces:
-                - stock-trading-*
+                - stock-trading        # admission-lab (single-cluster deep tests)
+                - stock-trading-*      # onboarding-lab (per-service clusters)
       validate:
         message: "Pod rejected: missing SBOM reference annotation (security.stock-trading.dev/sbom-digest)."
         pattern:


### PR DESCRIPTION
## Problem

Three back-to-back admission-lab runs (26223039189, 26223797929, 26223802016) all returned the same 5/7 PASS result with the same two cases failing:

- `NEG_MISSING_SBOM_DENY` -- expected Denied, got UnknownOrAllowed
- `NEG_CVE_THRESHOLD_DENY` -- expected Denied, got UnknownOrAllowed

This is **deterministic**, not flaky. The thesis currently cites Layer 3 as 7/7, based on an earlier lucky configuration.

## Root cause

`clusterpolicy-require-sbom.yaml` and `clusterpolicy-cve-threshold.yaml` both restrict their match scope to:

```yaml
namespaces:
  - stock-trading-*
```

The glob requires a suffix. This matches onboarding-lab namespaces (`stock-trading-user`, `stock-trading-apikey`, ...) but **not** admission-lab's namespace, which is the bare `stock-trading` with no suffix. Result: in admission-lab, the two policies silently do not apply, so the negative scenarios produce a non-deny verdict.

## Fix

Add `stock-trading` (no suffix) to the match list of both policies, alongside the existing glob:

```yaml
namespaces:
  - stock-trading        # admission-lab (single-cluster deep tests)
  - stock-trading-*      # onboarding-lab (per-service clusters)
```

The third policy (`clusterpolicy-verify-images.yaml`) is unaffected -- it matches by image reference, not namespace.

## Test plan

After merge, re-trigger `admission-matrix-evidence.yml` and expect Layer 3 to return to 7/7 PASS:
- NEG_MISSING_SBOM_DENY -- Denied (require-sbom-annotation now applies)
- NEG_CVE_THRESHOLD_DENY -- Denied (enforce-cve-threshold now applies)
- Other 5 cases unchanged