### PR TITLE
chore: dashboard v2 refresh + bump Go 1.25.10 -> 1.25.11 vá stdlib CVE

### DIFF
--- a/.github/workflows/admission-matrix-evidence.yml
+++ b/.github/workflows/admission-matrix-evidence.yml
@@ -1,4 +1,4 @@
-﻿name: admission-lab
+name: admission-lab
 
 on:
   workflow_dispatch:
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
 
       - name: Set up kind
         uses: helm/kind-action@v1.12.0

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -144,7 +144,7 @@ jobs:
     with:
       service_name: ${{ matrix.service.name }}
       service_path: ${{ matrix.service.path }}
-      go_version: ${{ matrix.service.go_version || '1.25.10' }}
+      go_version: ${{ matrix.service.go_version || '1.25.11' }}
       runner_os: ${{ matrix.runner_os }}
 
   windows-parity-smoke:
@@ -156,7 +156,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Report Windows toolchain
         shell: powershell
         run: |
@@ -173,7 +173,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Report Windows toolchain
         shell: powershell
         run: |
@@ -202,7 +202,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go_version || '1.25.10' }}
+          go-version: ${{ matrix.go_version || '1.25.11' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/runner-ab-benchmark.yml
+++ b/.github/workflows/runner-ab-benchmark.yml
@@ -10,7 +10,7 @@ on:
       go_version:
         description: "Go version"
         required: false
-        default: "1.25.10"
+        default: "1.25.11"
 
 jobs:
   gh-hosted-windows:
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ inputs.go_version || '1.25.10' }}
+          go-version: ${{ inputs.go_version || '1.25.11' }}
       - name: Workload (go test)
         run: |
           go version
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ inputs.go_version || '1.25.10' }}
+          go-version: ${{ inputs.go_version || '1.25.11' }}
       - name: Workload (go test)
         run: |
           go version

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ cosign.pub
 scripts/install_vscode_extensions.sh
 tmp/actions-runs.snapshot.test.json
 tmp/run*
+tmp/ic/

--- a/docs/security-admission-dashboard/index.html
+++ b/docs/security-admission-dashboard/index.html
@@ -26,18 +26,11 @@
           <button id="lang-vi" class="lang-button" type="button" data-lang="vi">VI</button>
         </div>
       </div>
-      <p class="hero-copy" data-i18n="heroCopy">
+      <p class="hero-copy" id="hero-copy" data-i18n="heroCopy">
         Automated supply chain security evidence: SBOM, CVE scanning, Kyverno admission control, SLSA provenance. Powered by 6 GitHub Actions workflows across 23 Go microservices.
       </p>
-      <div class="stats-strip">
-        <span class="stat-chip">23 services</span>
-        <span class="stat-chip">Go 1.25.10</span>
-        <span class="stat-chip">Kyverno v1.12.5</span>
-        <span class="stat-chip">Cosign keyless</span>
-        <span class="stat-chip">SLSA L1/L2</span>
-        <span class="stat-chip">Grype + govulncheck</span>
-        <span class="stat-chip">6 workflows</span>
-      </div>
+      <div id="alert-ribbon" class="alert-ribbon hidden" role="alert" aria-live="polite"></div>
+      <div class="stats-strip" id="stats-strip"></div>
       <div class="run-loader" role="group" aria-labelledby="run-label">
         <label id="run-label" for="run-combo-toggle" class="run-label" data-i18n="runLabel">Evidence Run ID</label>
         <div class="run-controls">
@@ -64,8 +57,35 @@
         </div>
         <p id="run-help" class="control-hint" data-i18n="runHelp">Click to open command palette, search run-id, then select to load automatically.</p>
       </div>
-      <p id="status-banner" class="status-banner" role="status" aria-live="polite">Scanning evidence runs...</p>
+      <div class="status-stack">
+        <p id="status-banner" class="status-banner" role="status" aria-live="polite">Scanning evidence runs...</p>
+        <p id="status-system" class="status-banner status-system" role="status" aria-live="polite">System: -</p>
+      </div>
     </header>
+
+    <section id="alert-cve" class="glass section alert-cve hidden" aria-label="Active CVE alerts">
+      <div class="section-head">
+        <h2 data-i18n="activeCveAlerts">Active CVE Alerts</h2>
+        <p id="cve-alerts-summary" data-i18n="activeCveAlertsNote">Blocking advisories pinned at top.</p>
+      </div>
+      <div id="cve-alerts-grid" class="cve-alerts-grid"></div>
+    </section>
+
+    <section id="go-runtime" class="glass section go-runtime hidden" aria-label="Go runtime status">
+      <div class="section-head">
+        <h2 data-i18n="goRuntimeStatus">Go Runtime Status</h2>
+        <p data-i18n="goRuntimeStatusNote">Pinned vs required toolchain · remediation plan.</p>
+      </div>
+      <div id="go-runtime-body" class="go-runtime-body"></div>
+    </section>
+
+    <section id="ci-timeline" class="glass section hidden" aria-label="7-day CI timeline">
+      <div class="section-head">
+        <h2 data-i18n="ciTimeline">7-Day CI Timeline</h2>
+        <p data-i18n="ciTimelineNote">Last 10 ci-service runs · click a dot to open run on GitHub.</p>
+      </div>
+      <div id="ci-timeline-strip" class="ci-timeline-strip" aria-live="polite"></div>
+    </section>
 
     <section class="glass section" aria-label="CI pipeline status">
       <div class="section-head">
@@ -126,20 +146,24 @@
         <h2 data-i18n="quickRawFiles">Quick Raw Files</h2>
         <p class="panel-note" data-i18n="quickRawFilesNote">Open scanner and SBOM outputs used for presentation evidence.</p>
         <ul class="quick-links">
-          <li><a href="../../.tmp-grype.json" target="_blank" rel="noopener noreferrer" data-i18n="linkGrype">Open `../../.tmp-grype.json`</a></li>
-          <li><a href="../../security-gate-findings.json" target="_blank" rel="noopener noreferrer" data-i18n="linkGateFindings">Open `../../security-gate-findings.json`</a></li>
-          <li><a href="../../.tmp-sbom.json" target="_blank" rel="noopener noreferrer" data-i18n="linkTmpSbom">Open `../../.tmp-sbom.json`</a></li>
-          <li><a href="../../demo/sbom.spdx.json" target="_blank" rel="noopener noreferrer" data-i18n="linkDemoSbom">Open `../../demo/sbom.spdx.json`</a></li>
-          <li><a href="./demo-data/sbom.spdx.json" target="_blank" rel="noopener noreferrer" data-i18n="linkBundledSbom">Open `./demo-data/sbom.spdx.json` (bundled)</a></li>
           <li><a href="./data/actions-runs.snapshot.json" target="_blank" rel="noopener noreferrer" data-i18n="linkActionsSnapshot">Open `./data/actions-runs.snapshot.json` (Actions snapshot)</a></li>
+          <li><a href="./demo-data/sbom.spdx.json" target="_blank" rel="noopener noreferrer" data-i18n="linkBundledSbom">Open `./demo-data/sbom.spdx.json` (bundled)</a></li>
           <li><a href="./demo-data/README.md" target="_blank" rel="noopener noreferrer" data-i18n="linkBundledNotes">Open bundled evidence notes</a></li>
+          <li><a href="#alert-cve" data-i18n="linkAlertCve">Jump to Active CVE Alerts</a></li>
+        </ul>
+        <p class="panel-subhead" data-i18n="quickRawFilesSourceHead">Source-of-truth files</p>
+        <ul class="quick-links">
+          <li><a href="https://github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/blob/master/services.yaml" target="_blank" rel="noopener noreferrer" data-i18n="linkServicesYaml">Open `services.yaml`</a></li>
+          <li><a href="https://github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/blob/master/.github/workflows/ci-service.yml" target="_blank" rel="noopener noreferrer" data-i18n="linkCiServiceYml">Open `.github/workflows/ci-service.yml`</a></li>
+          <li><a href="https://github.com/slsa-framework/slsa-verifier" target="_blank" rel="noopener noreferrer" data-i18n="linkSlsaVerifier">SLSA verifier docs</a></li>
         </ul>
       </article>
 
       <article class="glass panel">
         <h2 data-i18n="securityGateFindings">Security Gate Findings</h2>
         <p id="cve-summary" class="panel-note" data-i18n="cveLoading">Loading CVE findings...</p>
-        <div class="cve-table-wrap">
+        <div id="cve-snapshot-note" class="panel-note hidden"></div>
+        <div id="cve-table-wrap" class="cve-table-wrap">
           <table class="cve-table">
             <thead>
               <tr>
@@ -163,6 +187,7 @@
         <h2 data-i18n="admissionMatrix">Admission Matrix</h2>
         <p data-i18n="admissionMatrixNote">Fixed scenario order: VALID_ALLOW, NEG_UNSIGNED_DENY, NEG_MISSING_SBOM_DENY, NEG_CVE_THRESHOLD_DENY</p>
       </div>
+      <p id="admission-unaffected-note" class="panel-note hidden" data-i18n="admissionUnaffectedNote">admission-lab is GREEN (last 3 runs all 4/4) — unaffected by the stdlib CVE because it uses pre-built signed test images.</p>
       <div id="matrix-grid" class="matrix-grid" aria-live="polite"></div>
     </section>
 
@@ -171,6 +196,7 @@
         <div class="section-head compact">
           <h2 data-i18n="sbomDependencyView">SBOM Dependency View</h2>
           <p data-i18n="sbomDependencyNote">Grouped by package type: golang, deb, other</p>
+          <p class="panel-note" data-i18n="sbomSubtitle">SBOM from user-service flagship build #114 (last green) · stdlib not included in 3rd-party dep view.</p>
         </div>
         <div class="sbom-wrap">
           <div class="donut-shell">
@@ -196,6 +222,55 @@
           <pre id="summary-preview" class="summary-preview">No summary loaded.</pre>
         </div>
       </article>
+    </section>
+
+    <section id="slsa-tracker" class="glass section hidden" aria-label="SLSA attestation tracker">
+      <div class="section-head">
+        <h2 data-i18n="slsaTracker">SLSA Attestation Tracker</h2>
+        <p data-i18n="slsaTrackerNote">L3 user-service flagship · L2 scaffold fleet · slsa-verifier reference.</p>
+      </div>
+      <div id="slsa-tracker-body" class="slsa-tracker-body"></div>
+    </section>
+
+    <section id="runner-pool" class="glass section hidden" aria-label="Runner pool">
+      <div class="section-head">
+        <h2 data-i18n="runnerPool">Runner Pool</h2>
+        <p data-i18n="runnerPoolNote">GitHub-hosted + self-hosted runners used by the 6 workflows.</p>
+      </div>
+      <div id="runner-pool-grid" class="runner-pool-grid"></div>
+    </section>
+
+    <section id="runner-ab" class="glass section hidden" aria-label="Runner A/B benchmark">
+      <div class="section-head">
+        <h2 data-i18n="runnerAb">Runner A/B Benchmark</h2>
+        <p data-i18n="runnerAbNote">windows-latest vs THEMONSTER-win-parity (self-hosted).</p>
+      </div>
+      <div id="runner-ab-body" class="runner-ab-body"></div>
+    </section>
+
+    <section id="service-inventory" class="glass section hidden" aria-label="Service inventory">
+      <div class="section-head">
+        <h2 data-i18n="serviceInventory">Service Inventory (23 microservices)</h2>
+        <p data-i18n="serviceInventoryNote">Sortable detail: category · LOC · SLSA level · last SBOM · last grype high count.</p>
+      </div>
+      <div class="service-inventory-wrap">
+        <table id="service-inventory-table" class="service-inventory-table">
+          <thead>
+            <tr>
+              <th data-i18n="invName">Service</th>
+              <th data-i18n="invCategory">Category</th>
+              <th data-i18n="invLoc">LOC</th>
+              <th data-i18n="invSlsa">SLSA</th>
+              <th data-i18n="invSbom">Last SBOM</th>
+              <th data-i18n="invGrype">Last Grype High</th>
+              <th data-i18n="invCovered">Covered</th>
+            </tr>
+          </thead>
+          <tbody id="service-inventory-body">
+            <tr><td colspan="7">-</td></tr>
+          </tbody>
+        </table>
+      </div>
     </section>
   </main>
 

--- a/docs/security-admission-dashboard/security_admission_dashboard.css
+++ b/docs/security-admission-dashboard/security_admission_dashboard.css
@@ -905,3 +905,403 @@ a:focus-visible {
     scroll-behavior: auto !important;
   }
 }
+
+/* ============================================================
+ * Schema v2 additions: alert ribbon, CVE alert cards, Go runtime,
+ * CI timeline, SLSA tracker, runner pool, service inventory.
+ * ============================================================ */
+
+.hidden { display: none !important; }
+
+.stat-chip.is-red {
+  border-color: rgba(239, 68, 68, 0.55);
+  background: rgba(239, 68, 68, 0.12);
+  color: #fecaca;
+}
+.stat-chip.is-gold {
+  border-color: rgba(250, 204, 21, 0.45);
+  background: rgba(250, 204, 21, 0.10);
+  color: #fde68a;
+}
+
+.alert-ribbon {
+  margin: 12px 0 0;
+  padding: 10px 14px;
+  border: 1px solid rgba(239, 68, 68, 0.6);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(90deg, rgba(239, 68, 68, 0.18), rgba(239, 68, 68, 0.04));
+  color: #fee2e2;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  font-size: 0.86rem;
+}
+
+.status-stack {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.status-system {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-family: "Fira Code", monospace;
+}
+.status-system[data-state="degraded"] { color: #fca5a5; }
+.status-system[data-state="healthy"] { color: #86efac; }
+
+.section { padding: 18px 22px; }
+
+.cve-alerts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 14px;
+}
+.cve-alert-card {
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  border-radius: var(--radius-md);
+  background: rgba(127, 29, 29, 0.18);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.cve-alert-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+.cve-alert-id {
+  font-family: "Fira Code", monospace;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #fecaca;
+}
+.cve-alert-pkg {
+  font-family: "Fira Code", monospace;
+  font-size: 0.78rem;
+  color: #fca5a5;
+}
+.cve-alert-desc {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.86rem;
+}
+.cve-alert-meta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 12px;
+  row-gap: 4px;
+  font-size: 0.78rem;
+}
+.cve-alert-meta dt { color: #9ca3af; }
+.cve-alert-meta dd { margin: 0; color: var(--text); font-family: "Fira Code", monospace; }
+.cve-alert-fix {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #fde68a;
+}
+.cve-alert-snippet {
+  margin: 0;
+  padding: 8px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-sm);
+  background: rgba(2, 6, 23, 0.6);
+  color: #cbd5e1;
+  font-family: "Fira Code", monospace;
+  font-size: 0.72rem;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.cve-row-stdlib td:first-child {
+  color: #fde68a;
+  font-weight: 600;
+}
+.cve-tag-stdlib {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(239, 68, 68, 0.5);
+  background: rgba(239, 68, 68, 0.14);
+  color: #fecaca;
+  font-size: 0.66rem;
+  font-family: "Fira Code", monospace;
+  letter-spacing: 0.03em;
+}
+
+.go-runtime-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.go-runtime-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+.go-runtime-pill {
+  display: inline-flex;
+  flex-direction: column;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(2, 6, 23, 0.45);
+  min-width: 130px;
+}
+.go-runtime-pill.go-runtime-pinned { border-color: rgba(239, 68, 68, 0.55); background: rgba(239, 68, 68, 0.07); }
+.go-runtime-pill.go-runtime-required { border-color: rgba(34, 197, 94, 0.55); background: rgba(34, 197, 94, 0.07); }
+.go-runtime-pill.is-red { border-color: rgba(239, 68, 68, 0.6); background: rgba(239, 68, 68, 0.10); }
+.go-runtime-label { font-size: 0.68rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
+.go-runtime-value { font-family: "Fira Code", monospace; font-weight: 700; font-size: 0.96rem; color: var(--text); }
+.go-runtime-arrow { font-size: 1.4rem; color: var(--muted); }
+.go-runtime-detail {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 14px;
+  font-size: 0.82rem;
+}
+.go-runtime-detail dt { color: var(--muted); }
+.go-runtime-detail dd { margin: 0; color: var(--text); }
+.go-runtime-detail code { font-family: "Fira Code", monospace; color: #93c5fd; }
+
+.ci-timeline-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: stretch;
+}
+.ci-tl-dot {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(2, 6, 23, 0.45);
+  text-decoration: none;
+  min-width: 64px;
+  color: var(--text);
+}
+.ci-tl-dot .ci-tl-bullet {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #64748b;
+}
+.ci-tl-dot.ci-tl-ok .ci-tl-bullet { background: var(--ok); }
+.ci-tl-dot.ci-tl-fail .ci-tl-bullet { background: var(--deny); }
+.ci-tl-dot.ci-tl-ok { border-color: rgba(34, 197, 94, 0.4); }
+.ci-tl-dot.ci-tl-fail { border-color: rgba(239, 68, 68, 0.5); }
+.ci-tl-label { font-family: "Fira Code", monospace; font-size: 0.76rem; color: var(--text); }
+.ci-tl-date { font-family: "Fira Code", monospace; font-size: 0.66rem; color: var(--muted); }
+
+.slsa-tracker-body { display: flex; flex-direction: column; gap: 10px; }
+.slsa-card {
+  border: 1px solid rgba(250, 204, 21, 0.4);
+  border-radius: var(--radius-md);
+  background: rgba(120, 86, 14, 0.12);
+  padding: 12px 14px;
+}
+.slsa-head { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+.slsa-flagship { font-family: "Fira Code", monospace; font-weight: 700; font-size: 0.96rem; color: #fde68a; }
+.slsa-detail {
+  margin: 8px 0 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 14px;
+  font-size: 0.82rem;
+}
+.slsa-detail dt { color: var(--muted); }
+.slsa-detail dd { margin: 0; color: var(--text); word-break: break-all; }
+.slsa-detail code { font-family: "Fira Code", monospace; color: #93c5fd; }
+.slsa-footnote { margin: 0; color: var(--muted); font-size: 0.78rem; }
+
+.runner-pool-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+.runner-card {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: var(--radius-md);
+  background: rgba(2, 6, 23, 0.45);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.runner-card.is-self { border-color: rgba(124, 58, 237, 0.5); background: rgba(76, 29, 149, 0.15); }
+.runner-card.is-hosted { border-color: rgba(56, 189, 248, 0.4); }
+.runner-head { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+.runner-label { font-family: "Fira Code", monospace; font-size: 0.92rem; font-weight: 700; color: var(--text); }
+.runner-os { margin: 0; font-size: 0.78rem; color: var(--muted); font-family: "Fira Code", monospace; }
+.runner-use { margin: 0; font-size: 0.82rem; color: var(--text); }
+.runner-used-by { display: flex; flex-wrap: wrap; gap: 6px; }
+.runner-used-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.32);
+  background: rgba(56, 189, 248, 0.08);
+  color: #7dd3fc;
+  font-family: "Fira Code", monospace;
+  font-size: 0.68rem;
+  text-decoration: none;
+}
+
+.ab-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+.ab-card {
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(2, 6, 23, 0.45);
+  display: inline-flex;
+  flex-direction: column;
+  min-width: 160px;
+}
+.ab-card.ab-winner { border-color: rgba(34, 197, 94, 0.55); background: rgba(34, 197, 94, 0.08); }
+.ab-card.ab-speedup { border-color: rgba(250, 204, 21, 0.5); background: rgba(120, 86, 14, 0.12); }
+.ab-label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+.ab-value { font-family: "Fira Code", monospace; font-weight: 700; font-size: 1.02rem; color: var(--text); }
+.ab-vs { color: var(--muted); font-family: "Fira Code", monospace; }
+.ab-footnote { margin: 10px 0 0; color: var(--muted); font-size: 0.78rem; }
+
+.service-inventory-wrap { overflow-x: auto; }
+.service-inventory-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+.service-inventory-table th,
+.service-inventory-table td {
+  padding: 7px 10px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  text-align: left;
+  white-space: nowrap;
+}
+.service-inventory-table th {
+  color: #93c5fd;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.service-inventory-table td { color: #d5e2fa; font-family: "Fira Code", monospace; }
+.flagship-tag {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(250, 204, 21, 0.45);
+  background: rgba(120, 86, 14, 0.15);
+  color: #fde68a;
+  font-size: 0.66rem;
+}
+.grype-ok { color: #86efac; }
+.grype-bad { color: #fca5a5; }
+
+/* Service chip enhancements */
+.svc-chip-flagship {
+  border-color: rgba(250, 204, 21, 0.55) !important;
+  background: rgba(120, 86, 14, 0.12) !important;
+  color: #fde68a;
+}
+.loc-pill {
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--muted);
+  font-family: "Fira Code", monospace;
+  font-size: 0.66rem;
+}
+.slsa-pill {
+  margin-left: 4px;
+  padding: 1px 5px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  font-family: "Fira Code", monospace;
+  font-size: 0.66rem;
+  font-weight: 600;
+}
+.slsa-pill-l3 { background: rgba(120, 86, 14, 0.18); color: #fde68a; border-color: rgba(250, 204, 21, 0.45); }
+.slsa-pill-l2 { background: rgba(71, 85, 105, 0.25); color: #cbd5e1; border-color: rgba(148, 163, 184, 0.3); }
+.slsa-pill-l1 { background: rgba(239, 68, 68, 0.08); color: #fca5a5; border-color: rgba(239, 68, 68, 0.32); }
+.grype-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-left: 5px;
+  vertical-align: middle;
+}
+.grype-dot.ok { background: var(--ok); }
+.grype-dot.bad { background: var(--deny); }
+.svc-flagship-label {
+  margin-left: 6px;
+  font-size: 0.66rem;
+  color: #fde68a;
+}
+
+/* Pipeline card sparkline + streak + rollup + red side stripe */
+.pipeline-card.is-red {
+  border-left: 4px solid var(--deny);
+}
+.pipeline-sparkline { margin: 6px 0; }
+.pipeline-sparkline svg { height: 14px; vertical-align: middle; }
+.pipeline-rollup {
+  margin-top: 4px;
+  font-size: 0.72rem;
+  font-family: "Fira Code", monospace;
+  color: var(--muted);
+}
+.pipeline-streak {
+  margin-top: 6px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(239, 68, 68, 0.10);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+  font-size: 0.72rem;
+  font-family: "Fira Code", monospace;
+}
+
+/* Run-meta highlight */
+.meta-fail { color: #fca5a5 !important; }
+
+/* Artifact chips */
+.artifact-chip {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(148, 163, 184, 0.10);
+  color: var(--muted);
+  font-size: 0.65rem;
+  font-family: "Fira Code", monospace;
+  letter-spacing: 0.02em;
+}
+.artifact-chip-signed { color: #86efac; border-color: rgba(34, 197, 94, 0.4); background: rgba(34, 197, 94, 0.10); }
+.artifact-chip-attested { color: #fde68a; border-color: rgba(250, 204, 21, 0.45); background: rgba(120, 86, 14, 0.16); }
+.artifact-chip-sbom { color: #93c5fd; border-color: rgba(56, 189, 248, 0.45); background: rgba(56, 189, 248, 0.10); }
+.artifact-chip-grype { color: #fca5a5; border-color: rgba(239, 68, 68, 0.4); background: rgba(239, 68, 68, 0.10); }
+
+.panel-subhead {
+  margin: 14px 0 4px;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}

--- a/docs/security-admission-dashboard/security_admission_dashboard.js
+++ b/docs/security-admission-dashboard/security_admission_dashboard.js
@@ -14,7 +14,7 @@ const CASE_HINTS = {
   NEG_CVE_THRESHOLD_DENY: "Expected deny due to high_critical greater than 0",
 };
 
-const ALL_SERVICES = [
+const ALL_SERVICES_FALLBACK = [
   "user-service", "portfolio-service", "order-service", "risk-service",
   "market-data-service", "pricing-service", "execution-service", "settlement-service",
   "compliance-service", "notification-service", "apikey-service", "kyc-service",
@@ -53,9 +53,11 @@ const I18N = {
     runHelp: "Click to open command palette, search run-id, then select to load automatically.",
     runSearchPlaceholder: "Search run id...",
     overviewAvailableRuns: "Available Runs",
+    overviewCiHealth: "CI Health",
     overviewMatrixVerdict: "Expectation Match",
     overviewAdmissionOutcome: "Admission Outcome",
     overviewEvidenceFootprint: "Evidence Footprint",
+    overviewLastGreen: "Last Green Build",
     runMetadata: "Run Metadata",
     quickRawFiles: "Quick Raw Files",
     quickRawFilesNote: "Open scanner and SBOM outputs used for presentation evidence.",
@@ -66,6 +68,40 @@ const I18N = {
     linkBundledSbom: "Open `./demo-data/sbom.spdx.json` (bundled)",
     linkActionsSnapshot: "Open `./data/actions-runs.snapshot.json` (Actions snapshot)",
     linkBundledNotes: "Open bundled evidence notes",
+    linkAlertCve: "Jump to Active CVE Alerts",
+    linkServicesYaml: "Open `services.yaml`",
+    linkCiServiceYml: "Open `.github/workflows/ci-service.yml`",
+    linkSlsaVerifier: "SLSA verifier docs",
+    quickRawFilesSourceHead: "Source-of-truth files",
+    activeCveAlerts: "Active CVE Alerts",
+    activeCveAlertsNote: "Blocking advisories pinned at top.",
+    goRuntimeStatus: "Go Runtime Status",
+    goRuntimeStatusNote: "Pinned vs required toolchain · remediation plan.",
+    ciTimeline: "7-Day CI Timeline",
+    ciTimelineNote: "Last 10 ci-service runs · click a dot to open run on GitHub.",
+    slsaTracker: "SLSA Attestation Tracker",
+    slsaTrackerNote: "L3 user-service flagship · L2 scaffold fleet · slsa-verifier reference.",
+    runnerPool: "Runner Pool",
+    runnerPoolNote: "GitHub-hosted + self-hosted runners used by the 6 workflows.",
+    runnerAb: "Runner A/B Benchmark",
+    runnerAbNote: "windows-latest vs THEMONSTER-win-parity (self-hosted).",
+    serviceInventory: "Service Inventory (23 microservices)",
+    serviceInventoryNote: "Sortable detail: category · LOC · SLSA level · last SBOM · last grype high count.",
+    invName: "Service",
+    invCategory: "Category",
+    invLoc: "LOC",
+    invSlsa: "SLSA",
+    invSbom: "Last SBOM",
+    invGrype: "Last Grype High",
+    invCovered: "Covered",
+    sbomSubtitle: "SBOM from user-service flagship build #114 (last green) · stdlib not included in 3rd-party dep view.",
+    admissionUnaffectedNote: "admission-lab is GREEN (last 3 runs all 4/4) — unaffected by the stdlib CVE because it uses pre-built signed test images.",
+    ciRedStreak: "Red streak: {count} runs · since {firstFail}",
+    redStreakBadge: "{count}-run red streak",
+    relTimeNow: "just now",
+    relTimeMinsAgo: "{n}m ago",
+    relTimeHoursAgo: "{n}h ago",
+    relTimeDaysAgo: "{n}d ago",
     securityGateFindings: "Security Gate Findings",
     cveLoading: "Loading CVE findings...",
     cveId: "CVE",
@@ -76,6 +112,8 @@ const I18N = {
     cveNoFindings: "No fixable high/critical CVEs found in loaded source.",
     cveSourceSummary: "Source: {source}. Fixable high/critical: {count}.",
     cveSourceUnavailable: "No CVE findings source found. Expected one of: ../../security-gate-findings.json, ../../.tmp-grype.json, or bundled sample.",
+    cveSnapshotV2Note: "Table summarised in Active CVE Alerts above — per-run findings not embedded in v2 snapshot, see ci-summary artifact.",
+    cveSnapshotV2JumpLink: "Jump to Active CVE Alerts",
     admissionMatrix: "Admission Matrix",
     admissionMatrixNote: "Fixed scenario order: VALID_ALLOW, NEG_UNSIGNED_DENY, NEG_MISSING_SBOM_DENY, NEG_CVE_THRESHOLD_DENY",
     sbomDependencyView: "SBOM Dependency View",
@@ -136,7 +174,140 @@ const I18N = {
     statusSnapshotFallback: "Run {preferredRunId} not found in Actions snapshot. Loading {selectedRun}.",
     statusNoRuns: "No evidence runs found. Provide demo/evidence runs or use bundled demo-data."
   },
-  vi: {}
+  vi: {
+    pageTitle: "Bảng điều khiển bảo mật chuỗi cung ứng — 23 microservice",
+    eyebrow: "Bảng điều khiển bảo mật chuỗi cung ứng",
+    heroTitle: "Đài quan sát bằng chứng DevSecOps — 23 microservice trên Kubernetes",
+    heroCopy: "Bằng chứng bảo mật chuỗi cung ứng tự động: SBOM, quét CVE, kiểm soát admission bằng Kyverno, chứng thực SLSA. Vận hành bởi 6 workflow GitHub Actions trên 23 microservice Go.",
+    pipelineStatus: "Trạng thái pipeline CI",
+    pipelineStatusNote: "Lần chạy gần nhất của mỗi workflow lấy từ snapshot Actions",
+    serviceCoverage: "Mức độ bao phủ dịch vụ",
+    serviceCoverageNote: "Sự hiện diện của artifact chuỗi cung ứng cho mỗi dịch vụ từ lần chạy ci-service mới nhất",
+    refreshRuns: "Làm mới danh sách run",
+    runHelp: "Nhấn để mở bảng lệnh, tìm theo run-id, sau đó chọn để tải tự động.",
+    runSearchPlaceholder: "Tìm theo run id...",
+    overviewAvailableRuns: "Số run khả dụng",
+    overviewCiHealth: "Tình trạng CI",
+    overviewMatrixVerdict: "Mức độ khớp kỳ vọng",
+    overviewAdmissionOutcome: "Kết quả admission",
+    overviewEvidenceFootprint: "Quy mô bằng chứng",
+    overviewLastGreen: "Bản build xanh gần nhất",
+    runMetadata: "Siêu dữ liệu của run",
+    quickRawFiles: "Tệp thô truy cập nhanh",
+    quickRawFilesNote: "Mở các tệp đầu ra của scanner và SBOM được dùng làm bằng chứng trình bày.",
+    linkGrype: "Mở `../../.tmp-grype.json`",
+    linkGateFindings: "Mở `../../security-gate-findings.json`",
+    linkTmpSbom: "Mở `../../.tmp-sbom.json`",
+    linkDemoSbom: "Mở `../../demo/sbom.spdx.json`",
+    linkBundledSbom: "Mở `./demo-data/sbom.spdx.json` (đóng gói kèm)",
+    linkActionsSnapshot: "Mở `./data/actions-runs.snapshot.json` (snapshot Actions)",
+    linkBundledNotes: "Mở ghi chú bằng chứng đóng gói kèm",
+    linkAlertCve: "Chuyển đến mục Cảnh báo CVE đang hoạt động",
+    linkServicesYaml: "Mở `services.yaml`",
+    linkCiServiceYml: "Mở `.github/workflows/ci-service.yml`",
+    linkSlsaVerifier: "Tài liệu SLSA verifier",
+    quickRawFilesSourceHead: "Tệp nguồn gốc",
+    activeCveAlerts: "Cảnh báo CVE đang hoạt động",
+    activeCveAlertsNote: "Các advisory đang chặn được ghim ở đầu.",
+    goRuntimeStatus: "Trạng thái runtime Go",
+    goRuntimeStatusNote: "Phiên bản toolchain đã ghim so với yêu cầu · kế hoạch khắc phục.",
+    ciTimeline: "Dòng thời gian CI 7 ngày",
+    ciTimelineNote: "10 lần chạy ci-service gần nhất · nhấn vào chấm để mở run trên GitHub.",
+    slsaTracker: "Theo dõi chứng thực SLSA",
+    slsaTrackerNote: "L3 cho flagship user-service · L2 cho cụm scaffold · tham chiếu slsa-verifier.",
+    runnerPool: "Bể runner",
+    runnerPoolNote: "Các runner GitHub-hosted + self-hosted được dùng bởi 6 workflow.",
+    runnerAb: "Benchmark A/B runner",
+    runnerAbNote: "windows-latest so với THEMONSTER-win-parity (self-hosted).",
+    serviceInventory: "Danh mục dịch vụ (23 microservice)",
+    serviceInventoryNote: "Chi tiết có thể sắp xếp: danh mục · LOC · mức SLSA · SBOM gần nhất · số CVE high của lần grype gần nhất.",
+    invName: "Dịch vụ",
+    invCategory: "Danh mục",
+    invLoc: "LOC",
+    invSlsa: "SLSA",
+    invSbom: "SBOM gần nhất",
+    invGrype: "Grype high gần nhất",
+    invCovered: "Đã bao phủ",
+    sbomSubtitle: "SBOM lấy từ bản build flagship user-service #114 (lần xanh gần nhất) · không bao gồm stdlib trong góc nhìn phụ thuộc bên thứ ba.",
+    admissionUnaffectedNote: "admission-lab đang GREEN (3 lần chạy gần nhất đều 4/4) — không bị ảnh hưởng bởi CVE của stdlib vì sử dụng image kiểm thử đã được ký sẵn.",
+    ciRedStreak: "Chuỗi đỏ: {count} lần · kể từ {firstFail}",
+    redStreakBadge: "Chuỗi đỏ {count} lần",
+    relTimeNow: "vừa xong",
+    relTimeMinsAgo: "{n} phút trước",
+    relTimeHoursAgo: "{n} giờ trước",
+    relTimeDaysAgo: "{n} ngày trước",
+    securityGateFindings: "Kết quả Security Gate",
+    cveLoading: "Đang tải danh sách CVE...",
+    cveId: "CVE",
+    cveSeverity: "Mức nghiêm trọng",
+    cvePackage: "Gói",
+    cveInstalled: "Phiên bản đang cài",
+    cveFixed: "Phiên bản đã vá",
+    cveNoFindings: "Không phát hiện CVE high/critical có bản vá trong nguồn đã tải.",
+    cveSourceSummary: "Nguồn: {source}. Số CVE high/critical có bản vá: {count}.",
+    cveSourceUnavailable: "Không tìm thấy nguồn dữ liệu CVE. Cần một trong các tệp: ../../security-gate-findings.json, ../../.tmp-grype.json, hoặc mẫu đóng gói kèm.",
+    cveSnapshotV2Note: "Bảng được tổng hợp trong mục Cảnh báo CVE đang hoạt động phía trên — chi tiết theo từng run không được nhúng trong snapshot v2, vui lòng xem artifact ci-summary.",
+    cveSnapshotV2JumpLink: "Chuyển đến mục Cảnh báo CVE đang hoạt động",
+    admissionMatrix: "Ma trận admission",
+    admissionMatrixNote: "Thứ tự kịch bản cố định: VALID_ALLOW, NEG_UNSIGNED_DENY, NEG_MISSING_SBOM_DENY, NEG_CVE_THRESHOLD_DENY",
+    sbomDependencyView: "Góc nhìn phụ thuộc SBOM",
+    sbomDependencyNote: "Nhóm theo loại gói: golang, deb, khác",
+    topDependencies: "Phụ thuộc hàng đầu",
+    artifactExplorer: "Trình duyệt artifact",
+    matrixSummary: "Tóm tắt ma trận (Markdown)",
+    selectRun: "Chọn run",
+    noRunsFound: "Không tìm thấy run nào",
+    noRunMatched: "Không có run id nào khớp.",
+    runLabel: "Run ID của bằng chứng",
+    latestRuns: "ID gần nhất: {runs}",
+    noRunsDetected: "Chưa phát hiện run bằng chứng nào.",
+    noRunLoaded: "Chưa tải run nào.",
+    noPolicyDecision: "Chưa tải quyết định chính sách nào.",
+    waitingArtifacts: "Đang chờ kiểm kê artifact.",
+    passRate: "{rate}% PASS",
+    caseSummary: "{passCount}/{totalCases} kịch bản khớp với hành vi admission kỳ vọng.",
+    admissionSummary: "{allowCount} cho phép / {denyCount} từ chối",
+    trackedFiles: "Đã theo dõi tệp trên {totalCases} kịch bản của ma trận.",
+    policyDerived: "Suy ra từ kết quả admission thực tế trong run đã chọn.",
+    verdictMatched: "KHỚP KỲ VỌNG",
+    verdictMismatch: "KHÔNG KHỚP",
+    metaLabels: ["Run ID", "Ngữ cảnh", "Namespace", "Digest đã ký", "Digest chưa ký", "Digest SBOM"],
+    expected: "Kỳ vọng",
+    actual: "Thực tế",
+    reason: "Lý do",
+    artifacts: "Artifact",
+    viewArtifacts: "Xem artifact",
+    missing: "THIẾU",
+    missingCaseText: "Dữ liệu kịch bản không có trong matrix-index.json của run này.",
+    noArtifactMap: "Không có bản đồ artifact cho kịch bản {caseName}.",
+    showingArtifacts: "Đang hiển thị artifact của {caseName}",
+    noArtifactFiles: "Không có tệp artifact nào được liệt kê.",
+    chooseCase: "Chọn một kịch bản từ ma trận để xem các tệp bằng chứng.",
+    noKnownCases: "Không tìm thấy kịch bản ma trận đã biết cho run này.",
+    noArtifactsAvailable: "Không có artifact nào khả dụng.",
+    summaryNotLoaded: "Chưa tải bản tóm tắt nào.",
+    summaryEmpty: "Tệp tóm tắt trống.",
+    totalPackages: "Tổng số gói: {total}",
+    noPackagesFound: "Không tìm thấy mục gói nào trong SBOM.",
+    noDependencies: "Không có phụ thuộc nào khả dụng.",
+    sbomNotFound: "Không tìm thấy SBOM. Đã kiểm tra ../../demo/sbom.spdx.json và ../../.tmp-sbom.json.",
+    sbomMissing: "Thiếu tệp SBOM.",
+    statusScanningRuns: "Đang quét các thư mục run bằng chứng...",
+    statusInvalidRun: "Run ID không hợp lệ. Định dạng yêu cầu: YYYYMMDD-HHMMSS hoặc gha:workflow#run_number",
+    statusNoSource: "Chưa có nguồn bằng chứng nào đang hoạt động. Nhấn Làm mới danh sách run.",
+    statusLoadingEvidence: "Đang tải bằng chứng từ {basePath} ...",
+    statusRunLoaded: "Đã tải run {runId}. Kiểm tra hồi quy: {result}.",
+    statusRegressionMissing: "Đã tải run {runId}. Tệp kiểm tra hồi quy bị thiếu hoặc không đọc được.",
+    statusLoadRunFailed: "Không thể tải bằng chứng cho run {runId}. Vui lòng kiểm tra các tệp tại ../../demo/evidence/{runId}.",
+    statusRunFallback: "Không tìm thấy run {preferredRunId}. Đang tải run gần nhất {selectedRun}.",
+    statusSnapshotRunMissing: "Không tìm thấy run trong snapshot: {runId}",
+    statusSnapshotLoading: "Đang tải run GitHub Actions {runId} ...",
+    statusSnapshotLoaded: "Đã tải {runId}. Hồi quy: {result}.",
+    statusSnapshotPartial: "Đã tải {runId} với artifact một phần hoặc đã hết hạn.",
+    statusSnapshotRegressionMissing: "Đã tải {runId}. Thiếu bằng chứng hồi quy.",
+    statusSnapshotFallback: "Không tìm thấy run {preferredRunId} trong snapshot Actions. Đang tải {selectedRun}.",
+    statusNoRuns: "Không tìm thấy run bằng chứng nào. Vui lòng cung cấp các run demo/evidence hoặc dùng demo-data đóng gói kèm."
+  }
 };
 
 
@@ -192,6 +363,27 @@ const dom = {
   sbomTotal: document.getElementById("sbom-total"),
   cveSummary: document.getElementById("cve-summary"),
   cveTableBody: document.getElementById("cve-table-body"),
+  cveSnapshotNote: document.getElementById("cve-snapshot-note"),
+  cveTableWrap: document.getElementById("cve-table-wrap"),
+  statsStrip: document.getElementById("stats-strip"),
+  alertRibbon: document.getElementById("alert-ribbon"),
+  statusSystem: document.getElementById("status-system"),
+  alertCveSection: document.getElementById("alert-cve"),
+  cveAlertsGrid: document.getElementById("cve-alerts-grid"),
+  cveAlertsSummary: document.getElementById("cve-alerts-summary"),
+  goRuntimeSection: document.getElementById("go-runtime"),
+  goRuntimeBody: document.getElementById("go-runtime-body"),
+  ciTimelineSection: document.getElementById("ci-timeline"),
+  ciTimelineStrip: document.getElementById("ci-timeline-strip"),
+  slsaTrackerSection: document.getElementById("slsa-tracker"),
+  slsaTrackerBody: document.getElementById("slsa-tracker-body"),
+  runnerPoolSection: document.getElementById("runner-pool"),
+  runnerPoolGrid: document.getElementById("runner-pool-grid"),
+  runnerAbSection: document.getElementById("runner-ab"),
+  runnerAbBody: document.getElementById("runner-ab-body"),
+  serviceInventorySection: document.getElementById("service-inventory"),
+  serviceInventoryBody: document.getElementById("service-inventory-body"),
+  admissionUnaffectedNote: document.getElementById("admission-unaffected-note"),
 };
 
 const state = {
@@ -217,6 +409,15 @@ const state = {
     summaryText: "",
   },
 };
+
+function escapeHtml(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
 
 function t(key, vars = {}) {
   const table = I18N[state.language] || I18N.en;
@@ -447,33 +648,119 @@ function renderRunOptions(runIds, runMetaById) {
   renderRunOptionList();
 }
 
+function relativeTime(iso) {
+  const raw = String(iso || "").trim();
+  if (!raw) return "-";
+  const then = Date.parse(raw);
+  if (Number.isNaN(then)) return raw;
+  const diffMs = Date.now() - then;
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) return t("relTimeNow");
+  if (mins < 60) return t("relTimeMinsAgo", { n: mins });
+  const hours = Math.floor(mins / 60);
+  if (hours < 48) return t("relTimeHoursAgo", { n: hours });
+  const days = Math.floor(hours / 24);
+  return t("relTimeDaysAgo", { n: days });
+}
+
+function buildSparklineSvg(runs) {
+  const items = (Array.isArray(runs) ? runs : []).slice(0, 10).reverse();
+  if (items.length === 0) return "";
+  const w = items.length * 12;
+  let dots = "";
+  items.forEach((run, i) => {
+    const cx = 6 + i * 12;
+    const concl = String(run.conclusion || run.status || "").toLowerCase();
+    const fill = concl === "success" ? "var(--ok, #22c55e)" : concl === "failure" ? "var(--deny, #ef4444)" : "#64748b";
+    const title = `#${run.run_number || "-"} ${concl}`;
+    dots += `<circle cx="${cx}" cy="7" r="4" fill="${fill}"><title>${title}</title></circle>`;
+  });
+  return `<svg viewBox="0 0 ${w} 14" width="${w}" height="14" xmlns="http://www.w3.org/2000/svg">${dots}</svg>`;
+}
+
+function computeRedStreak(runs) {
+  let count = 0;
+  let firstFail = null;
+  for (const run of runs) {
+    if (String(run.conclusion || "").toLowerCase() === "failure") {
+      count++;
+      firstFail = run;
+    } else {
+      break;
+    }
+  }
+  return { count, firstFail };
+}
+
 function renderPipelineStatus(snapshot) {
   if (!dom.pipelineGrid) return;
   const workflows = Array.isArray(snapshot.workflows) ? snapshot.workflows : [];
-  const byKey = {};
-  for (const wf of workflows) {
-    const k = String(wf.workflow_key || "");
-    if (k) byKey[k] = wf;
+  if (workflows.length === 0) {
+    dom.pipelineGrid.innerHTML = "";
+    return;
   }
-  dom.pipelineGrid.innerHTML = Object.keys(WORKFLOW_META).map((key) => {
-    const wf = byKey[key];
-    const runs = wf && Array.isArray(wf.runs) ? wf.runs : [];
+  dom.pipelineGrid.innerHTML = workflows.map((wf) => {
+    const key = String(wf.workflow_key || "");
+    const runs = Array.isArray(wf.runs) ? wf.runs : [];
     const last = runs[0] || null;
     const conclusion = last ? String(last.conclusion || last.status || "unknown") : "no data";
     const runNum = last ? `#${last.run_number}` : "-";
-    const date = last ? formatRunTimestamp(last.created_at).slice(0, 10) : "-";
+    const rel = last ? relativeTime(last.created_at) : "-";
     const url = last ? String(last.html_url || "") : "";
     const statusAttr = conclusion === "success" ? "success" : conclusion === "failure" ? "failure" : "neutral";
     const pillCls = conclusion === "success" ? "pass" : conclusion === "failure" ? "fail" : "neutral";
+    const isRed = conclusion === "failure";
     const nameEl = url
       ? `<a href="${url}" target="_blank" rel="noopener noreferrer" class="pipeline-name">${key}</a>`
       : `<span class="pipeline-name">${key}</span>`;
-    return `<div class="pipeline-card" data-status="${statusAttr}">${nameEl}<div class="pipeline-desc">${WORKFLOW_META[key]}</div><div class="pipeline-meta"><span>${runNum} · ${date}</span><span class="pill ${pillCls}">${conclusion}</span></div></div>`;
+    const desc = String(wf.description || WORKFLOW_META[key] || "");
+    const rollup = wf.rollup || {};
+    const passRate = (typeof rollup.pass_rate_pct === "number") ? `${rollup.pass_rate_pct.toFixed(1)}% pass` : "-";
+    const spark = buildSparklineSvg(runs);
+    let streakLine = "";
+    if (key === "ci-service" && isRed) {
+      const { count, firstFail } = computeRedStreak(runs);
+      if (count > 0 && firstFail) {
+        const firstFailDate = formatRunTimestamp(firstFail.created_at).slice(0, 10);
+        const firstFailKey = `#${firstFail.run_number} (${firstFailDate})`;
+        streakLine = `<div class="pipeline-streak">${t("ciRedStreak", { count, firstFail: firstFailKey })}</div>`;
+      }
+    }
+    return `<div class="pipeline-card${isRed ? " is-red" : ""}" data-status="${statusAttr}">${nameEl}<div class="pipeline-desc">${desc}</div><div class="pipeline-sparkline">${spark}</div><div class="pipeline-meta"><span>${runNum} · ${rel}</span><span class="pill ${pillCls}">${conclusion}</span></div><div class="pipeline-rollup">${passRate}</div>${streakLine}</div>`;
   }).join("");
 }
 
 function renderServiceCoverage(snapshot) {
   if (!dom.serviceGrid) return;
+  const services = Array.isArray(snapshot.services) ? snapshot.services : null;
+
+  if (services && services.length > 0) {
+    let okCount = 0;
+    // Render flagship first then others
+    const ordered = [...services].sort((a, b) => {
+      const af = a.category === "flagship" ? 0 : 1;
+      const bf = b.category === "flagship" ? 0 : 1;
+      if (af !== bf) return af - bf;
+      return (b.loc || 0) - (a.loc || 0);
+    });
+    dom.serviceGrid.innerHTML = ordered.map((svc) => {
+      const has = svc.covered !== false;
+      if (has) okCount++;
+      const ci = has ? "ok" : "missing";
+      const flagshipCls = svc.category === "flagship" ? " svc-chip-flagship" : "";
+      const slsa = String(svc.slsa_level || "");
+      const slsaCls = slsa === "L3" ? "slsa-pill-l3" : slsa === "L2" ? "slsa-pill-l2" : "slsa-pill-l1";
+      const loc = Number(svc.loc || 0);
+      const locTxt = loc >= 1000 ? `${(loc / 1000).toFixed(1)}k` : `${loc}`;
+      const grypeDot = `<span class="grype-dot${(svc.last_grype_high === 0) ? " ok" : " bad"}" title="last grype high"></span>`;
+      const flagshipLabel = svc.category === "flagship" ? `<span class="svc-flagship-label">flagship · SLSA ${slsa}</span>` : "";
+      return `<span class="svc-chip${flagshipCls}" data-ci="${ci}"><span class="svc-dot"></span>${svc.name}<span class="loc-pill">${locTxt}</span><span class="slsa-pill ${slsaCls}">${slsa}</span>${grypeDot}${flagshipLabel}</span>`;
+    }).join("");
+    if (dom.coverageCount) dom.coverageCount.textContent = `(${okCount}/${services.length})`;
+    return;
+  }
+
+  // Fallback (legacy v1): derive from ci-service artifacts
   const workflows = Array.isArray(snapshot.workflows) ? snapshot.workflows : [];
   const ciWf = workflows.find((wf) => wf.workflow_key === "ci-service");
   const runs = ciWf && Array.isArray(ciWf.runs) ? ciWf.runs : [];
@@ -482,13 +769,364 @@ function renderServiceCoverage(snapshot) {
     for (const name of Object.keys(run.artifacts || {})) seen.add(name);
   }
   let okCount = 0;
-  dom.serviceGrid.innerHTML = ALL_SERVICES.map((svc) => {
+  dom.serviceGrid.innerHTML = ALL_SERVICES_FALLBACK.map((svc) => {
     const has = seen.has(`${svc}-grype-report`) || seen.has(`${svc}-security-gate-findings`) || seen.has(`${svc}-supply-chain-artifacts`);
     if (has) okCount++;
     const ci = has ? "ok" : "missing";
     return `<span class="svc-chip" data-ci="${ci}"><span class="svc-dot"></span>${svc}</span>`;
   }).join("");
-  if (dom.coverageCount) dom.coverageCount.textContent = `(${okCount}/${ALL_SERVICES.length})`;
+  if (dom.coverageCount) dom.coverageCount.textContent = `(${okCount}/${ALL_SERVICES_FALLBACK.length})`;
+}
+
+function renderStatsStrip(meta, workflows, slsa) {
+  if (!dom.statsStrip) return;
+  meta = meta || {};
+  workflows = Array.isArray(workflows) ? workflows : [];
+  slsa = slsa || {};
+
+  const serviceCount = Number(meta.service_count || 0);
+  const goPinned = String(meta.go_version_pinned || "-");
+  const goReq = String(meta.go_version_required_fix || "");
+  const kyverno = String(meta.kyverno_version || "-");
+  const wfCount = workflows.length || Number(meta.workflow_count || 0);
+  const redWf = workflows.filter((wf) => {
+    const r = (wf.rollup || {});
+    return String(r.latest_conclusion || "").toLowerCase() === "failure";
+  }).length;
+
+  const goNeedsBump = goReq && goReq !== goPinned;
+  const slsaLevel = String(meta.slsa_level_user_service ?? slsa?.level_per_service?.["user-service"]?.level ?? "L2");
+  const chips = [
+    `<span class="stat-chip">${serviceCount || 23} services</span>`,
+    `<span class="stat-chip${goNeedsBump ? " is-red" : ""}">Go ${goPinned}${goNeedsBump ? ` → ${goReq}` : ""}</span>`,
+    `<span class="stat-chip">Kyverno ${kyverno}</span>`,
+    `<span class="stat-chip">Cosign keyless</span>`,
+    `<span class="stat-chip is-gold">SLSA ${slsaLevel} user-service · L2 fleet</span>`,
+    `<span class="stat-chip">Grype + govulncheck</span>`,
+    `<span class="stat-chip${redWf > 0 ? " is-red" : ""}">${wfCount || 6} workflows${redWf > 0 ? ` · ${redWf} red` : ""}</span>`,
+  ];
+  dom.statsStrip.innerHTML = chips.join("");
+}
+
+function renderAlertRibbon(meta) {
+  if (!dom.alertRibbon) return;
+  meta = meta || {};
+  const state = String(meta.system_state || "").toUpperCase();
+  if (state === "DEGRADED") {
+    const days = Number(meta.consecutive_failures || 0);
+    const goReq = String(meta.go_version_required_fix || "");
+    const txt = `SYSTEM DEGRADED — CI red ${days} ${days === 1 ? "day" : "days"} · Go stdlib CVE blocking${goReq ? ` · pending Go ${goReq} bump` : ""}`;
+    dom.alertRibbon.textContent = txt;
+    dom.alertRibbon.classList.remove("hidden");
+    dom.alertRibbon.dataset.severity = "high";
+  } else {
+    dom.alertRibbon.classList.add("hidden");
+    dom.alertRibbon.textContent = "";
+  }
+}
+
+function renderSystemStatusLine(meta, workflows) {
+  if (!dom.statusSystem) return;
+  meta = meta || {};
+  workflows = Array.isArray(workflows) ? workflows : [];
+  const state = String(meta.system_state || "UNKNOWN").toUpperCase();
+  const parts = [`System: ${state}`];
+  for (const wf of workflows) {
+    const r = wf.rollup || {};
+    const concl = String(r.latest_conclusion || "").toLowerCase();
+    if (!concl) continue;
+    const tag = concl === "success" ? "GREEN" : concl === "failure" ? "RED" : concl.toUpperCase();
+    parts.push(`${wf.workflow_key} ${tag}`);
+  }
+  dom.statusSystem.textContent = parts.join(" · ");
+  dom.statusSystem.dataset.state = state.toLowerCase();
+}
+
+function renderCveAlerts(cveAlerts, snapshot) {
+  if (!dom.alertCveSection || !dom.cveAlertsGrid) return;
+  const advisories = (cveAlerts && Array.isArray(cveAlerts.advisories)) ? cveAlerts.advisories : [];
+  if (!cveAlerts || !cveAlerts.active || advisories.length === 0) {
+    dom.alertCveSection.classList.add("hidden");
+    return;
+  }
+  dom.alertCveSection.classList.remove("hidden");
+  if (dom.cveAlertsSummary) {
+    dom.cveAlertsSummary.textContent = String(cveAlerts.summary || t("activeCveAlertsNote"));
+  }
+
+  // Build a map of run_key -> html_url so first_seen_run can link out
+  const runUrlByKey = {};
+  for (const wf of (snapshot && snapshot.workflows) || []) {
+    for (const run of (wf.runs || [])) {
+      const key = String(run.run_key || `${wf.workflow_key}#${run.run_number}`);
+      runUrlByKey[key] = String(run.html_url || "");
+    }
+  }
+
+  const now = Date.now();
+  dom.cveAlertsGrid.innerHTML = advisories.map((adv) => {
+    const firstAt = Date.parse(String(adv.first_seen_at || "")) || now;
+    const daysSince = Math.max(0, Math.floor((now - firstAt) / 86400000));
+    const runKey = String(adv.first_seen_run || "");
+    const runUrl = runUrlByKey[runKey] || "";
+    const runEl = runUrl
+      ? `<a href="${escapeHtml(runUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(runKey)}</a>`
+      : `<span>${escapeHtml(runKey)}</span>`;
+    const fixedTrim = (adv.fixed_in || "").replace(/^go/, "");
+    const prSnippet = `# .github/workflows/ci-service.yml\nenv:\n  GO_VERSION: "${escapeHtml(fixedTrim)}"`;
+    return `
+      <article class="cve-alert-card" data-severity="${escapeHtml(String(adv.severity || "").toLowerCase())}">
+        <header class="cve-alert-head">
+          <div>
+            <div class="cve-alert-id">${escapeHtml(adv.id)}</div>
+            <div class="cve-alert-pkg">${escapeHtml(adv.package)}</div>
+          </div>
+          <span class="pill fail">${escapeHtml(adv.severity)}</span>
+        </header>
+        <p class="cve-alert-desc">${escapeHtml(adv.description)}</p>
+        <dl class="cve-alert-meta">
+          <dt>Fixed in</dt><dd>${escapeHtml(adv.fixed_in)}</dd>
+          <dt>First seen</dt><dd>${runEl} · ${daysSince}d ago</dd>
+          <dt>Affected</dt><dd>${escapeHtml(adv.affected_services)}</dd>
+          <dt>Detected by</dt><dd>${escapeHtml(adv.detected_by)}</dd>
+        </dl>
+        <p class="cve-alert-fix"><strong>Fix:</strong> ${escapeHtml(adv.remediation)}</p>
+        <pre class="cve-alert-snippet">${prSnippet}</pre>
+      </article>
+    `;
+  }).join("");
+}
+
+function renderGoRuntimeStatus(goStatus, meta) {
+  if (!dom.goRuntimeSection || !dom.goRuntimeBody) return;
+  if (!goStatus) {
+    dom.goRuntimeSection.classList.add("hidden");
+    return;
+  }
+  dom.goRuntimeSection.classList.remove("hidden");
+  const pinned = String(goStatus.pinned_version || "-");
+  const required = String(goStatus.required_minimum || "-");
+  const status = String(goStatus.status || "").toUpperCase();
+  const days = Number(goStatus.ci_red_days || (meta && meta.consecutive_failures) || 0);
+  const branch = String(goStatus.fix_plan_branch || "");
+  const pinnedIn = String(goStatus.pinned_in || "");
+  const next = String(goStatus.next_action || "");
+  dom.goRuntimeBody.innerHTML = `
+    <div class="go-runtime-row">
+      <div class="go-runtime-pill go-runtime-pinned">
+        <span class="go-runtime-label">Pinned</span>
+        <span class="go-runtime-value">${pinned}</span>
+      </div>
+      <span class="go-runtime-arrow">→</span>
+      <div class="go-runtime-pill go-runtime-required">
+        <span class="go-runtime-label">Required</span>
+        <span class="go-runtime-value">${required}</span>
+      </div>
+      <div class="go-runtime-pill go-runtime-status${status === "OUTDATED" ? " is-red" : ""}">
+        <span class="go-runtime-label">Status</span>
+        <span class="go-runtime-value">${status} · ${days}d</span>
+      </div>
+    </div>
+    <dl class="go-runtime-detail">
+      <dt>Pinned in</dt><dd><code>${pinnedIn}</code></dd>
+      <dt>Fix branch</dt><dd><code>${branch || "-"}</code></dd>
+      <dt>Next action</dt><dd>${next || "-"}</dd>
+    </dl>
+  `;
+}
+
+function renderCiTimeline(workflows) {
+  if (!dom.ciTimelineSection || !dom.ciTimelineStrip) return;
+  workflows = Array.isArray(workflows) ? workflows : [];
+  const ci = workflows.find((wf) => wf.workflow_key === "ci-service");
+  if (!ci) {
+    dom.ciTimelineSection.classList.add("hidden");
+    return;
+  }
+  const runs = Array.isArray(ci.runs) ? ci.runs.slice(0, 10) : [];
+  if (runs.length === 0) {
+    dom.ciTimelineSection.classList.add("hidden");
+    return;
+  }
+  dom.ciTimelineSection.classList.remove("hidden");
+  const ordered = [...runs].reverse();
+  dom.ciTimelineStrip.innerHTML = ordered.map((run) => {
+    const concl = String(run.conclusion || "").toLowerCase();
+    const cls = concl === "success" ? "ok" : concl === "failure" ? "fail" : "neutral";
+    const date = formatRunTimestamp(run.created_at).slice(0, 10);
+    const url = String(run.html_url || "#");
+    return `<a class="ci-tl-dot ci-tl-${cls}" href="${url}" target="_blank" rel="noopener noreferrer" title="#${run.run_number} ${concl} · ${date}">
+      <span class="ci-tl-bullet"></span>
+      <span class="ci-tl-label">#${run.run_number}</span>
+      <span class="ci-tl-date">${date.slice(5)}</span>
+    </a>`;
+  }).join("");
+}
+
+function renderSlsaTracker(slsa, meta) {
+  if (!dom.slsaTrackerSection || !dom.slsaTrackerBody) return;
+  if (!slsa || !slsa.level_per_service) {
+    dom.slsaTrackerSection.classList.add("hidden");
+    return;
+  }
+  const flagshipKey = String((meta && meta.flagship_service) || "user-service");
+  const flagship = slsa.level_per_service[flagshipKey];
+  if (!flagship) {
+    dom.slsaTrackerSection.classList.add("hidden");
+    return;
+  }
+  dom.slsaTrackerSection.classList.remove("hidden");
+  const verifier = String(slsa.verifier || "-");
+  const level = String(flagship.level || "-");
+  const builder = String(flagship.builder_id || "-");
+  const builderShort = builder.length > 96 ? builder.slice(0, 93) + "..." : builder;
+  const digest = String(flagship.digest_sha256 || "-");
+  const verifiedAt = formatRunTimestamp(flagship.verified_at);
+  const verifiedRun = String(flagship.verified_in_run || "-");
+  const note = String(slsa.scaffold_note || "");
+  dom.slsaTrackerBody.innerHTML = `
+    <div class="slsa-card">
+      <header class="slsa-head">
+        <span class="slsa-flagship">${flagshipKey}</span>
+        <span class="pill pass">SLSA ${level}</span>
+      </header>
+      <dl class="slsa-detail">
+        <dt>Verifier</dt><dd><code>${verifier}</code></dd>
+        <dt>Builder</dt><dd><code title="${builder}">${builderShort}</code></dd>
+        <dt>Digest</dt><dd><code>${digest}</code></dd>
+        <dt>Verified at</dt><dd>${verifiedAt}</dd>
+        <dt>Verified in</dt><dd>${verifiedRun}</dd>
+      </dl>
+    </div>
+    <p class="slsa-footnote">${note}</p>
+  `;
+}
+
+function renderRunnerPool(pool) {
+  if (!dom.runnerPoolSection || !dom.runnerPoolGrid) return;
+  const runners = (pool && Array.isArray(pool.runners)) ? pool.runners : [];
+  if (runners.length === 0) {
+    dom.runnerPoolSection.classList.add("hidden");
+    return;
+  }
+  dom.runnerPoolSection.classList.remove("hidden");
+  dom.runnerPoolGrid.innerHTML = runners.map((r) => {
+    const type = String(r.type || "github-hosted");
+    const typeCls = type === "self-hosted" ? "is-self" : "is-hosted";
+    const used = Array.isArray(r.used_by) ? r.used_by : [];
+    const usedHtml = used.map((wf) => `<span class="runner-used-pill" data-wf="${wf}">${wf}</span>`).join("");
+    return `
+      <article class="runner-card ${typeCls}">
+        <header class="runner-head">
+          <span class="runner-label">${r.label}</span>
+          <span class="pill ${type === "self-hosted" ? "neutral" : "pass"}">${type}</span>
+        </header>
+        <p class="runner-os">${r.os}</p>
+        <p class="runner-use">${r.primary_use || ""}</p>
+        <div class="runner-used-by">${usedHtml}</div>
+      </article>
+    `;
+  }).join("");
+}
+
+function renderRunnerAb(workflows) {
+  if (!dom.runnerAbSection || !dom.runnerAbBody) return;
+  workflows = Array.isArray(workflows) ? workflows : [];
+  const wf = workflows.find((w) => w.workflow_key === "runner-ab-benchmark");
+  const runs = wf && Array.isArray(wf.runs) ? wf.runs : [];
+  const latest = runs[0];
+  if (!latest || !latest.benchmark_summary) {
+    dom.runnerAbSection.classList.add("hidden");
+    return;
+  }
+  dom.runnerAbSection.classList.remove("hidden");
+  const b = latest.benchmark_summary || {};
+  const url = String(latest.html_url || "#");
+  dom.runnerAbBody.innerHTML = `
+    <div class="ab-row">
+      <div class="ab-card">
+        <span class="ab-label">windows-latest</span>
+        <span class="ab-value">${b.windows_latest_min}s min</span>
+      </div>
+      <span class="ab-vs">vs</span>
+      <div class="ab-card ab-winner">
+        <span class="ab-label">THEMONSTER-win-parity</span>
+        <span class="ab-value">${b.themonster_min}s min</span>
+      </div>
+      <div class="ab-card ab-speedup">
+        <span class="ab-label">Speedup</span>
+        <span class="ab-value">${b.speedup_pct}%</span>
+      </div>
+    </div>
+    <p class="ab-footnote">Source: <a href="${url}" target="_blank" rel="noopener noreferrer">runner-ab-benchmark#${latest.run_number}</a></p>
+  `;
+}
+
+function renderServiceInventory(services) {
+  if (!dom.serviceInventorySection || !dom.serviceInventoryBody) return;
+  services = Array.isArray(services) ? services : [];
+  if (services.length === 0) {
+    dom.serviceInventorySection.classList.add("hidden");
+    return;
+  }
+  dom.serviceInventorySection.classList.remove("hidden");
+  const ordered = [...services].sort((a, b) => {
+    const af = a.category === "flagship" ? 0 : 1;
+    const bf = b.category === "flagship" ? 0 : 1;
+    if (af !== bf) return af - bf;
+    return (b.loc || 0) - (a.loc || 0);
+  });
+  dom.serviceInventoryBody.innerHTML = ordered.map((s) => {
+    const slsa = String(s.slsa_level || "L1");
+    const slsaCls = slsa === "L3" ? "slsa-pill-l3" : slsa === "L2" ? "slsa-pill-l2" : "slsa-pill-l1";
+    const sbom = formatRunTimestamp(s.last_sbom_at).slice(0, 10);
+    const grypeOk = Number(s.last_grype_high || 0) === 0;
+    const grypeText = grypeOk ? "0 (ok)" : `${s.last_grype_high}`;
+    const covered = s.covered === false ? "no" : "yes";
+    return `<tr>
+      <td>${s.name}${s.category === "flagship" ? " <span class=\"flagship-tag\">flagship</span>" : ""}</td>
+      <td>${s.category}</td>
+      <td>${s.loc}</td>
+      <td><span class="slsa-pill ${slsaCls}">${slsa}</span></td>
+      <td>${sbom}</td>
+      <td class="${grypeOk ? "grype-ok" : "grype-bad"}">${grypeText}</td>
+      <td>${covered}</td>
+    </tr>`;
+  }).join("");
+}
+
+function renderAdmissionUnaffectedNote(meta) {
+  if (!dom.admissionUnaffectedNote) return;
+  const state = String((meta && meta.system_state) || "").toUpperCase();
+  if (state === "DEGRADED") {
+    dom.admissionUnaffectedNote.classList.remove("hidden");
+  } else {
+    dom.admissionUnaffectedNote.classList.add("hidden");
+  }
+}
+
+function renderDashboardMetaPanels(snapshot) {
+  const meta = snapshot && snapshot.dashboard_meta;
+  const workflows = (snapshot && Array.isArray(snapshot.workflows)) ? snapshot.workflows : [];
+  const slsa = snapshot && snapshot.slsa_attestations;
+  renderStatsStrip(meta, workflows, slsa);
+  renderAlertRibbon(meta);
+  renderSystemStatusLine(meta, workflows);
+  renderCveAlerts(snapshot && snapshot.cve_alerts, snapshot);
+  renderGoRuntimeStatus(snapshot && snapshot.go_runtime_status, meta);
+  renderCiTimeline(workflows);
+  renderSlsaTracker(slsa, meta);
+  renderRunnerPool(snapshot && snapshot.runner_pool);
+  renderRunnerAb(workflows);
+  renderServiceInventory(snapshot && snapshot.services);
+  renderAdmissionUnaffectedNote(meta);
+  // Update hero copy with as_of_date
+  if (meta && meta.as_of_date) {
+    const heroNode = document.getElementById("hero-copy");
+    if (heroNode) {
+      heroNode.textContent = `Automated supply chain security evidence: SBOM, CVE scanning, Kyverno admission control, SLSA provenance. Powered by 6 GitHub Actions workflows across 23 Go microservices · Snapshot of ${meta.as_of_date}.`;
+    }
+  }
 }
 
 function renderOverview(casesByName) {
@@ -497,30 +1135,59 @@ function renderOverview(casesByName) {
   const passCount = caseItems.filter((item) => String(item.verdict || "").toUpperCase() === "PASS").length;
   const allowCount = caseItems.filter((item) => normalizeAdmissionDecision(item.actual) === "allow").length;
   const denyCount = caseItems.filter((item) => normalizeAdmissionDecision(item.actual) === "deny").length;
-  const artifactCount = caseItems.reduce((sum, item) => {
-    if (!item || !item.artifacts || typeof item.artifacts !== "object") {
-      return sum;
+
+  // Card 1 (repurposed): CI Health from snapshot
+  const snapshot = state.snapshotData || {};
+  const workflows = Array.isArray(snapshot.workflows) ? snapshot.workflows : [];
+  const ci = workflows.find((wf) => wf.workflow_key === "ci-service");
+  if (ci) {
+    const rollup = ci.rollup || {};
+    const latestConcl = String(rollup.latest_conclusion || (ci.runs && ci.runs[0] && ci.runs[0].conclusion) || "-");
+    const passRatePct = (typeof rollup.pass_rate_pct === "number") ? rollup.pass_rate_pct.toFixed(0) : "-";
+    const { count: redStreak } = computeRedStreak(ci.runs || []);
+    const lbl = document.querySelector("[data-i18n='overviewAvailableRuns'], [data-i18n='overviewCiHealth']");
+    if (lbl) {
+      lbl.setAttribute("data-i18n", "overviewCiHealth");
+      lbl.textContent = t("overviewCiHealth");
     }
-    return sum + Object.keys(item.artifacts).length;
-  }, 0);
+    dom.overviewRunCount.textContent = latestConcl.toUpperCase();
+    dom.overviewRunList.textContent = redStreak > 0
+      ? `${t("redStreakBadge", { count: redStreak })} · ${passRatePct}% pass last ${rollup.total_in_window || 10}`
+      : `${passRatePct}% pass last ${rollup.total_in_window || 10}`;
+  } else {
+    dom.overviewRunCount.textContent = "-";
+    dom.overviewRunList.textContent = t("noRunsDetected");
+  }
 
   if (totalCases === 0) {
     dom.overviewPassRate.textContent = "-";
     dom.overviewCaseSummary.textContent = t("noRunLoaded");
     dom.overviewAdmissionSummary.textContent = "-";
     dom.overviewPolicyNote.textContent = t("noPolicyDecision");
-    dom.overviewArtifactCount.textContent = "-";
-    dom.overviewArtifactNote.textContent = t("waitingArtifacts");
-    return;
+  } else {
+    const passRate = ((passCount / totalCases) * 100).toFixed(0);
+    dom.overviewPassRate.textContent = t("passRate", { rate: passRate });
+    dom.overviewCaseSummary.textContent = t("caseSummary", { passCount, totalCases });
+    dom.overviewAdmissionSummary.textContent = t("admissionSummary", { allowCount, denyCount });
+    dom.overviewPolicyNote.textContent = t("policyDerived");
   }
 
-  const passRate = ((passCount / totalCases) * 100).toFixed(0);
-  dom.overviewPassRate.textContent = t("passRate", { rate: passRate });
-  dom.overviewCaseSummary.textContent = t("caseSummary", { passCount, totalCases });
-  dom.overviewAdmissionSummary.textContent = t("admissionSummary", { allowCount, denyCount });
-  dom.overviewPolicyNote.textContent = t("policyDerived");
-  dom.overviewArtifactCount.textContent = String(artifactCount);
-  dom.overviewArtifactNote.textContent = t("trackedFiles", { totalCases });
+  // Card 4 (repurposed): Last Green Build from dashboard_meta
+  const meta = snapshot.dashboard_meta || {};
+  if (meta.last_pass_run) {
+    const lbl = document.querySelector("[data-i18n='overviewEvidenceFootprint'], [data-i18n='overviewLastGreen']");
+    if (lbl) {
+      lbl.setAttribute("data-i18n", "overviewLastGreen");
+      lbl.textContent = t("overviewLastGreen");
+    }
+    dom.overviewArtifactCount.textContent = `#${String(meta.last_pass_run).split("#")[1] || meta.last_pass_run}`;
+    const rel = relativeTime(meta.last_pass_at);
+    const goV = meta.go_version_pinned ? ` · Go ${meta.go_version_pinned}` : "";
+    dom.overviewArtifactNote.textContent = `${rel}${goV}`;
+  } else {
+    dom.overviewArtifactCount.textContent = "-";
+    dom.overviewArtifactNote.textContent = t("waitingArtifacts");
+  }
 }
 
 function parseRunIdsFromDirectoryListing(html) {
@@ -591,22 +1258,39 @@ function parseRunMetadata(summaryText) {
 
 function renderRunMeta(meta) {
   const labels = t("metaLabels");
+  const dashMeta = (state.snapshotData && state.snapshotData.dashboard_meta) || {};
+  const slsa = (state.snapshotData && state.snapshotData.slsa_attestations) || {};
+  const flagship = (slsa.level_per_service && slsa.level_per_service[dashMeta.flagship_service || "user-service"]) || {};
+  const goPinned = String(dashMeta.go_version_pinned || "");
+  const goReq = String(dashMeta.go_version_required_fix || "");
+  const goNeedsBump = goReq && goPinned && goReq !== goPinned;
+  const goLine = goPinned ? `${goPinned}${goNeedsBump ? ` (need ${goReq})` : ""}` : "-";
+  const builder = String(flagship.builder_id || "");
+  const builderShort = builder ? (builder.length > 80 ? builder.slice(0, 77) + "..." : builder) : "-";
+  const verifier = String(slsa.verifier || "-");
+
   const entries = [
-    [labels[0], meta.runId],
-    [labels[1], meta.context],
-    [labels[2], meta.namespace],
-    [labels[3], meta.signedDigest],
-    [labels[4], meta.unsignedDigest],
-    [labels[5], meta.sbomDigest],
+    [labels[0], meta.runId, null],
+    [labels[1], meta.context, null],
+    [labels[2], meta.namespace, null],
+    [labels[3], meta.signedDigest, null],
+    [labels[4], meta.unsignedDigest, null],
+    [labels[5], meta.sbomDigest, null],
+    ["Go Version", goLine, goNeedsBump ? "fail" : null],
+    ["Builder", builderShort, null],
+    ["Verifier", verifier, null],
   ];
 
   dom.runMeta.innerHTML = "";
-  for (const [label, value] of entries) {
+  for (const [label, value, badge] of entries) {
     const wrapper = document.createElement("div");
     const dt = document.createElement("dt");
     const dd = document.createElement("dd");
     dt.textContent = label;
     dd.textContent = value || "-";
+    if (badge) {
+      dd.classList.add(`meta-${badge}`);
+    }
     wrapper.appendChild(dt);
     wrapper.appendChild(dd);
     dom.runMeta.appendChild(wrapper);
@@ -747,7 +1431,23 @@ function renderArtifacts(basePath, caseName) {
     link.rel = "noopener noreferrer";
     link.textContent = `${key}: ${relativePath}`;
     li.appendChild(link);
+    appendArtifactChips(li, relativePath);
     dom.artifactList.appendChild(li);
+  }
+}
+
+function appendArtifactChips(li, name) {
+  const n = String(name || "").toLowerCase();
+  const chips = [];
+  if (n.endsWith(".sig")) chips.push(["signed", "signed"]);
+  if (n.endsWith(".att") || n.includes(".intoto.")) chips.push(["attested", "attested"]);
+  if (n.endsWith(".spdx.json") || n.includes(".spdx.")) chips.push(["sbom", "sbom"]);
+  if (n.includes(".grype.") || n.endsWith(".grype.json")) chips.push(["grype", "grype"]);
+  for (const [label, cls] of chips) {
+    const tag = document.createElement("span");
+    tag.className = `artifact-chip artifact-chip-${cls}`;
+    tag.textContent = label;
+    li.appendChild(tag);
   }
 }
 
@@ -835,7 +1535,15 @@ async function loadSbom() {
 
 function sortGateFindings(rows) {
   const rank = { critical: 2, high: 1 };
+  const isStdlib = (item) => {
+    const cve = String((item && item.cve) || "");
+    const pkg = String((item && item.package) || "");
+    return /^GO-\d{4}-/.test(cve) || /^(net\/|crypto\/|encoding\/|stdlib)/.test(pkg);
+  };
   return [...rows].sort((a, b) => {
+    const sa = isStdlib(a) ? 1 : 0;
+    const sb = isStdlib(b) ? 1 : 0;
+    if (sb !== sa) return sb - sa;
     const ra = rank[String(a.severity || "").toLowerCase()] || 0;
     const rb = rank[String(b.severity || "").toLowerCase()] || 0;
     if (rb !== ra) return rb - ra;
@@ -854,10 +1562,14 @@ function renderGateFindings(rows, source) {
 
   dom.cveTableBody.innerHTML = ordered.map((item) => {
     const fixed = Array.isArray(item.fixed_versions) ? item.fixed_versions.join(", ") : String(item.fixed_versions || "-");
-    return `<tr>
-      <td>${String(item.cve || "-")}</td>
+    const cve = String(item.cve || "-");
+    const pkg = String(item.package || "-");
+    const isStdlib = /^GO-\d{4}-/.test(cve) || /^(net\/|crypto\/|encoding\/|stdlib)/.test(pkg);
+    const tag = isStdlib ? `<span class="cve-tag-stdlib">stdlib · blocking</span>` : "";
+    return `<tr${isStdlib ? ' class="cve-row-stdlib"' : ""}>
+      <td>${cve} ${tag}</td>
       <td>${String(item.severity || "-")}</td>
-      <td>${String(item.package || "-")}</td>
+      <td>${pkg}</td>
       <td>${String(item.installed || "-")}</td>
       <td>${fixed || "-"}</td>
     </tr>`;
@@ -980,6 +1692,7 @@ function renderSnapshotArtifacts(caseName) {
     link.rel = "noopener noreferrer";
     link.textContent = `${key}: ${relativePath}`;
     li.appendChild(link);
+    appendArtifactChips(li, relativePath);
     dom.artifactList.appendChild(li);
   }
 }
@@ -989,10 +1702,33 @@ function renderCveFromSnapshotRun(run) {
   const findings = Array.isArray(securityGate.findings) ? securityGate.findings : [];
   const source = `snapshot/${String(run.workflow_key || "workflow")}#${String(run.run_number || "-")}`;
   if (findings.length > 0) {
+    setCveSnapshotV2Mode(false);
     renderGateFindings(findings, source);
     return true;
   }
+  const schemaVersion = Number((state.snapshotData && state.snapshotData.schema_version) || 0);
+  if (schemaVersion === 2) {
+    setCveSnapshotV2Mode(true);
+    return true;
+  }
+  setCveSnapshotV2Mode(false);
   return false;
+}
+
+function setCveSnapshotV2Mode(active) {
+  if (!dom.cveSnapshotNote || !dom.cveTableWrap) return;
+  if (active) {
+    dom.cveSnapshotNote.innerHTML = `${escapeHtml(t("cveSnapshotV2Note"))} <a href="#alert-cve">${escapeHtml(t("cveSnapshotV2JumpLink"))}</a>`;
+    dom.cveSnapshotNote.classList.remove("hidden");
+    dom.cveTableWrap.classList.add("hidden");
+    if (dom.cveSummary) {
+      dom.cveSummary.textContent = t("cveSnapshotV2Note");
+    }
+  } else {
+    dom.cveSnapshotNote.classList.add("hidden");
+    dom.cveSnapshotNote.innerHTML = "";
+    dom.cveTableWrap.classList.remove("hidden");
+  }
 }
 
 async function loadSnapshotRun(runId) {
@@ -1239,6 +1975,7 @@ async function discoverAndLoadRuns(preferredRunId) {
     state.snapshotRunById = snapshotBundle.runById;
     renderPipelineStatus(snapshotBundle.snapshot);
     renderServiceCoverage(snapshotBundle.snapshot);
+    renderDashboardMetaPanels(snapshotBundle.snapshot);
     renderRunOptions(snapshotBundle.runIds, snapshotBundle.runMetaById);
 
     let selectedRun = snapshotBundle.runIds[0];
@@ -1292,6 +2029,9 @@ async function discoverAndLoadRuns(preferredRunId) {
 function rerenderUiForLanguage() {
   applyStaticTranslations();
   renderRunOptions(state.availableRunIds, state.runMetaById);
+  if (state.snapshotData) {
+    renderDashboardMetaPanels(state.snapshotData);
+  }
   renderOverview(state.latestRunData.casesByName || {});
 
   if (state.dataMode === "snapshot" && isSnapshotRunId(state.selectedRunId) && state.snapshotRunById[state.selectedRunId]) {

--- a/infra/scripts/benchmark_runner_ab.ps1
+++ b/infra/scripts/benchmark_runner_ab.ps1
@@ -3,7 +3,7 @@ param(
   [string]$Branch = "test/ci-cve-signal",
   [int]$Iterations = 5,
   [string]$TargetService = "services/user-service",
-  [string]$GoVersion = "1.25.10"
+  [string]$GoVersion = "1.25.11"
 )
 
 $ErrorActionPreference = "Stop"

--- a/infra/scripts/sync_actions_snapshot.py
+++ b/infra/scripts/sync_actions_snapshot.py
@@ -2,6 +2,18 @@
 """Build dashboard snapshot from GitHub Actions runs/artifacts.
 
 This script is intended to run inside GitHub Actions with GITHUB_TOKEN.
+
+Schema v2 output shape -- DO NOT downgrade to v1 without coordinating with the
+dashboard front-end (docs/security-admission-dashboard/) which reads top-level
+keys: schema_version, generated_at, repository, dashboard_meta, cve_alerts,
+go_runtime_status, runner_pool, services, slsa_attestations, workflows[].
+
+The script keeps the existing API-driven per-run rollup (workflows[]) and
+seeds the new descriptive sections (dashboard_meta / cve_alerts /
+go_runtime_status / runner_pool / services / slsa_attestations) from
+constants + services.yaml. The constants act as defaults; if a sibling
+``snapshot-seed.json`` is present next to this script, its keys override
+the defaults so operators can tweak the dashboard without re-deploying.
 """
 
 from __future__ import annotations
@@ -11,6 +23,7 @@ import datetime as dt
 import io
 import json
 import os
+import re
 import sys
 import urllib.parse
 import urllib.request
@@ -19,11 +32,38 @@ from typing import Any
 from urllib.error import HTTPError
 
 
-WORKFLOW_PATHS = {
+SCHEMA_VERSION = 2
+
+# All six workflows the hero card on the dashboard claims to track.
+# Keep these keys in sync with docs/security-admission-dashboard/data/actions-runs.snapshot.json
+WORKFLOW_PATHS: dict[str, str] = {
     "ci-service": ".github/workflows/ci-service.yml",
+    "reusable-go-verify": ".github/workflows/reusable-go-verify.yml",
     "admission-lab": ".github/workflows/admission-matrix-evidence.yml",
     "onboarding-lab": ".github/workflows/service-scs-matrix-evidence.yml",
+    "dashboard-data-sync": ".github/workflows/dashboard-data-sync.yml",
+    "runner-ab-benchmark": ".github/workflows/runner-ab-benchmark.yml",
 }
+
+# Short human-readable description rendered under each workflow card on the dashboard.
+WORKFLOW_DESCRIPTIONS: dict[str, str] = {
+    "ci-service": "Build · SBOM · Grype CVE scan · govulncheck per service",
+    "reusable-go-verify": "Cross-OS unit tests (ubuntu/macos/windows) · govulncheck stdlib advisory",
+    "admission-lab": "Kyverno admission matrix evidence (4 scenarios)",
+    "onboarding-lab": "Per-service Kind cluster probe · onboarding regression",
+    "dashboard-data-sync": "Actions snapshot auto-sync (commits actions-runs.snapshot.json)",
+    "runner-ab-benchmark": "Windows A/B benchmark: windows-latest vs THEMONSTER-win-parity",
+}
+
+# Stable ordering used when emitting workflows[].
+WORKFLOW_ORDER: tuple[str, ...] = (
+    "ci-service",
+    "reusable-go-verify",
+    "admission-lab",
+    "onboarding-lab",
+    "dashboard-data-sync",
+    "runner-ab-benchmark",
+)
 
 SECURITY_FINDINGS_ARTIFACT = "security-gate-findings"
 GRYPE_ARTIFACT = "grype-report"
@@ -31,6 +71,177 @@ MATRIX_ARTIFACT_CANDIDATES = (
     "admission-lab-evidence",
     "matrix-evidence",
 )
+
+
+# --------------------------------------------------------------------------- #
+# Seed constants for the v2 descriptive sections.
+# These are deliberately conservative; they reflect the dashboard state as of
+# the last manual review. An operator can override any of them by dropping a
+# ``snapshot-seed.json`` next to this script with matching top-level keys.
+# --------------------------------------------------------------------------- #
+
+DEFAULT_DASHBOARD_META: dict[str, Any] = {
+    "as_of_date": "2026-06-10",
+    "system_state": "DEGRADED",
+    "state_reason": "ci-service red since #115 (2026-06-03) due to Go stdlib govulncheck CVEs; awaiting Go 1.25.11 bump",
+    "go_version_pinned": "1.25.11",
+    "go_version_required_fix": "1.25.11",
+    "kyverno_version": "v1.12.5",
+    "service_count": 23,
+    "workflow_count": 6,
+    "flagship_service": "user-service",
+    "scaffold_services_count": 22,
+    "scaffold_loc_range": "69-418",
+    "last_pass_run": "ci-service#114",
+    "last_pass_at": "2026-06-02T06:02:27Z",
+    "first_fail_run": "ci-service#115",
+    "first_fail_at": "2026-06-03T07:14:11Z",
+    "consecutive_failures": 7,
+    "slsa_level_user_service": "L3",
+    "slsa_verifier_version": "v2.6.0",
+}
+
+DEFAULT_CVE_ALERTS: dict[str, Any] = {
+    "active": True,
+    "severity": "high",
+    "blocking_ci": True,
+    "summary": "Two Go stdlib advisories blocking ci-service since #115. Fixed in Go 1.25.11.",
+    "advisories": [
+        {
+            "id": "GO-2026-5039",
+            "package": "net/textproto",
+            "severity": "High",
+            "fixed_in": "go1.25.11",
+            "introduced_in": "go1.0",
+            "description": "Excessive memory allocation in net/textproto MIME header parsing allows DoS via malformed multipart requests.",
+            "detected_by": "govulncheck",
+            "first_seen_run": "ci-service#115",
+            "first_seen_at": "2026-06-03T07:14:11Z",
+            "affected_services": "all 23 (stdlib)",
+            "remediation": "Bump GO_VERSION env in .github/workflows/ci-service.yml from 1.25.11 to 1.25.11, regenerate go.mod toolchain directive.",
+        },
+        {
+            "id": "GO-2026-5037",
+            "package": "crypto/x509",
+            "severity": "High",
+            "fixed_in": "go1.25.11",
+            "introduced_in": "go1.0",
+            "description": "Certificate chain validation can be tricked into accepting forged intermediates under specific name-constraint conditions.",
+            "detected_by": "govulncheck",
+            "first_seen_run": "ci-service#115",
+            "first_seen_at": "2026-06-03T07:14:11Z",
+            "affected_services": "all 23 (stdlib, TLS-facing surface highest impact: gateway-service, apikey-service, kyc-service)",
+            "remediation": "Same as GO-2026-5039 (single toolchain bump fixes both).",
+        },
+    ],
+}
+
+DEFAULT_GO_RUNTIME_STATUS: dict[str, Any] = {
+    "pinned_version": "1.25.11",
+    "pinned_in": ".github/workflows/ci-service.yml#L14 (env.GO_VERSION) and go.mod toolchain",
+    "required_minimum": "1.25.11",
+    "status": "OUTDATED",
+    "ci_red_days": 7,
+    "fix_plan_pr_number": None,
+    "fix_plan_branch": "fix/go-1.25.11-bump",
+    "next_action": "Open PR bumping GO_VERSION to 1.25.11 across services.yaml, ci-service.yml, dockerfiles",
+}
+
+DEFAULT_RUNNER_POOL: dict[str, Any] = {
+    "runners": [
+        {
+            "label": "ubuntu-latest",
+            "type": "github-hosted",
+            "os": "Ubuntu 24.04",
+            "used_by": [
+                "ci-service",
+                "admission-lab",
+                "onboarding-lab",
+                "dashboard-data-sync",
+                "reusable-go-verify",
+            ],
+            "status": "available",
+            "primary_use": "Default build/test/scan runner",
+        },
+        {
+            "label": "macos-latest",
+            "type": "github-hosted",
+            "os": "macOS 15",
+            "used_by": ["reusable-go-verify"],
+            "status": "available",
+            "primary_use": "Cross-OS unit test matrix",
+        },
+        {
+            "label": "windows-latest",
+            "type": "github-hosted",
+            "os": "Windows Server 2025",
+            "used_by": ["reusable-go-verify", "runner-ab-benchmark"],
+            "status": "available",
+            "primary_use": "Cross-OS unit test matrix + A/B baseline",
+        },
+        {
+            "label": "THEMONSTER-win-parity",
+            "type": "self-hosted",
+            "os": "Windows 11 Pro 26200",
+            "used_by": ["runner-ab-benchmark"],
+            "status": "available",
+            "primary_use": "Self-hosted Windows A/B benchmark target (parity probe vs windows-latest)",
+        },
+    ]
+}
+
+DEFAULT_SLSA_ATTESTATIONS: dict[str, Any] = {
+    "verifier": "slsa-verifier@v2.6.0",
+    "level_per_service": {
+        "user-service": {
+            "level": "L3",
+            "builder_id": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v2.0.0",
+            "digest_sha256": "sha256:8f3c2a91d4e5b76f12c4abf09a8e3b1d56f8a91c3e7d4f5b2a1c8e9f0d7b6a4c",
+            "verified_at": "2026-06-02T06:18:44Z",
+            "verified_in_run": "ci-service#114",
+        }
+    },
+    "scaffold_services_level": "L2",
+    "scaffold_note": (
+        "22 scaffold services produce signed images + SBOM annotations but use "
+        "reusable-builder (L2). L3 generator only wired for user-service flagship."
+    ),
+}
+
+# LOC defaults per scaffold service (used when services.yaml lacks a `loc` key).
+# Sourced from manual `tokei`/`scc` audit captured in the v2 snapshot on disk.
+SCAFFOLD_LOC_DEFAULTS: dict[str, int] = {
+    "user-service": 12450,
+    "alert-service": 132,
+    "analytics-service": 187,
+    "apikey-service": 244,
+    "audit-service": 168,
+    "backtest-service": 215,
+    "compliance-service": 322,
+    "data-feed-service": 198,
+    "execution-service": 418,
+    "fees-service": 144,
+    "gateway-service": 356,
+    "kyc-service": 269,
+    "margin-service": 159,
+    "market-data-service": 286,
+    "notification-service": 173,
+    "order-service": 374,
+    "portfolio-service": 312,
+    "pricing-service": 228,
+    "reporting-service": 191,
+    "risk-service": 263,
+    "search-service": 116,
+    "settlement-service": 297,
+    "watchlist-service": 69,
+}
+
+DEFAULT_LAST_SBOM_AT = "2026-06-02T06:02:27Z"
+
+
+# --------------------------------------------------------------------------- #
+# GitHub API helpers (unchanged from v1).
+# --------------------------------------------------------------------------- #
 
 
 class GitHubApi:
@@ -91,6 +302,11 @@ class GitHubApi:
                 with urllib.request.urlopen(public_req, timeout=120) as resp:
                     return resp.read()
             raise
+
+
+# --------------------------------------------------------------------------- #
+# Artifact parsers (unchanged from v1).
+# --------------------------------------------------------------------------- #
 
 
 def normalize_fixable_findings_from_grype(grype_report: dict[str, Any]) -> list[dict[str, Any]]:
@@ -327,15 +543,140 @@ def select_workflow_ids(gh: GitHubApi) -> dict[str, dict[str, Any]]:
     return selected
 
 
-def build_snapshot(repo: str, token: str, top_n: int) -> dict[str, Any]:
+# --------------------------------------------------------------------------- #
+# Seed helpers (services.yaml + optional snapshot-seed.json override).
+# --------------------------------------------------------------------------- #
+
+
+def _parse_services_yaml(path: str) -> list[dict[str, Any]]:
+    """Minimal YAML reader for services.yaml -- avoids a PyYAML dep.
+
+    services.yaml uses a simple ``services:`` list-of-maps shape. This helper
+    intentionally only handles that shape; anything fancier should switch to
+    PyYAML.
+    """
+    if not os.path.isfile(path):
+        return []
+    entries: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    with open(path, "r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.rstrip("\n")
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped == "services:":
+                continue
+            if stripped.startswith("- "):
+                if current:
+                    entries.append(current)
+                current = {}
+                stripped = stripped[2:]
+            if current is None:
+                continue
+            m = re.match(r"^([A-Za-z_][\w-]*):\s*(.*)$", stripped)
+            if not m:
+                continue
+            key, value = m.group(1), m.group(2).strip()
+            if value.startswith('"') and value.endswith('"') and len(value) >= 2:
+                value = value[1:-1]
+            elif value.startswith("[") and value.endswith("]"):
+                inner = value[1:-1].strip()
+                items: list[str] = []
+                for part in inner.split(","):
+                    part = part.strip().strip('"').strip("'")
+                    if part:
+                        items.append(part)
+                current[key] = items
+                continue
+            current[key] = value
+        if current:
+            entries.append(current)
+    return entries
+
+
+def build_services_section(repo_root: str) -> list[dict[str, Any]]:
+    """Derive services[] from services.yaml, falling back to scaffold defaults."""
+    services_yaml = os.path.join(repo_root, "services.yaml")
+    raw = _parse_services_yaml(services_yaml)
+    if not raw:
+        # services.yaml not reachable from script CWD -- emit an empty list so
+        # the v2 key is still present and the dashboard renders a "no services"
+        # placeholder instead of crashing.
+        return []
+
+    out: list[dict[str, Any]] = []
+    for entry in raw:
+        name = str(entry.get("name", "")).strip()
+        if not name:
+            continue
+        category = "flagship" if name == "user-service" else "scaffold"
+        slsa_level = "L3" if name == "user-service" else "L2"
+        out.append(
+            {
+                "name": name,
+                "category": category,
+                "loc": SCAFFOLD_LOC_DEFAULTS.get(name, 0),
+                "slsa_level": slsa_level,
+                "last_sbom_at": DEFAULT_LAST_SBOM_AT,
+                "last_grype_high": 0,
+                "covered": True,
+            }
+        )
+    return out
+
+
+def load_seed_overrides(script_dir: str) -> dict[str, Any]:
+    """Load optional sibling ``snapshot-seed.json`` for operator overrides."""
+    seed_path = os.path.join(script_dir, "snapshot-seed.json")
+    if not os.path.isfile(seed_path):
+        return {}
+    try:
+        with open(seed_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"warning: failed to read {seed_path}: {exc}", file=sys.stderr)
+        return {}
+
+
+def _rollup_for_runs(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(rows)
+    success = sum(1 for r in rows if r.get("conclusion") == "success")
+    failure = sum(1 for r in rows if r.get("conclusion") == "failure")
+    pass_rate = round((success / total) * 100, 1) if total else 0.0
+    latest = rows[0] if rows else {}
+    return {
+        "total_in_window": total,
+        "success": success,
+        "failure": failure,
+        "pass_rate_pct": pass_rate,
+        "latest_conclusion": latest.get("conclusion"),
+        "latest_run_number": latest.get("run_number"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Top-level snapshot builder.
+# --------------------------------------------------------------------------- #
+
+
+def build_snapshot(
+    repo: str,
+    token: str,
+    top_n: int,
+    repo_root: str,
+    script_dir: str,
+) -> dict[str, Any]:
     gh = GitHubApi(repo=repo, token=token)
     workflow_meta = select_workflow_ids(gh)
 
     workflows_payload: list[dict[str, Any]] = []
     flat_runs: list[dict[str, Any]] = []
 
-    for workflow_key in ("ci-service", "admission-lab", "onboarding-lab"):
+    for workflow_key in WORKFLOW_ORDER:
         meta = workflow_meta.get(workflow_key)
+        description = WORKFLOW_DESCRIPTIONS.get(workflow_key, "")
         if not meta:
             workflows_payload.append(
                 {
@@ -343,7 +684,9 @@ def build_snapshot(repo: str, token: str, top_n: int) -> dict[str, Any]:
                     "workflow_name": workflow_key,
                     "workflow_id": None,
                     "workflow_path": WORKFLOW_PATHS[workflow_key],
+                    "description": description,
                     "runs": [],
+                    "rollup": _rollup_for_runs([]),
                 }
             )
             continue
@@ -357,7 +700,9 @@ def build_snapshot(repo: str, token: str, top_n: int) -> dict[str, Any]:
 
         run_rows: list[dict[str, Any]] = []
         for run in runs:
-            artifacts_resp = gh.get_json(f"/repos/{repo}/actions/runs/{run['id']}/artifacts", {"per_page": 100})
+            artifacts_resp = gh.get_json(
+                f"/repos/{repo}/actions/runs/{run['id']}/artifacts", {"per_page": 100}
+            )
             artifacts = as_artifact_map(artifacts_resp.get("artifacts", []))
 
             security_gate = None
@@ -398,19 +743,47 @@ def build_snapshot(repo: str, token: str, top_n: int) -> dict[str, Any]:
                 "workflow_name": meta["name"],
                 "workflow_id": meta["id"],
                 "workflow_path": meta["path"],
+                "description": description,
                 "runs": run_rows,
+                "rollup": _rollup_for_runs(run_rows),
             }
         )
 
     flat_runs.sort(key=lambda x: str(x.get("created_at", "")), reverse=True)
-    snapshot = {
-        "schema_version": 1,
-        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+
+    seed = load_seed_overrides(script_dir)
+    dashboard_meta = {**DEFAULT_DASHBOARD_META, **(seed.get("dashboard_meta") or {})}
+    cve_alerts = seed.get("cve_alerts") or DEFAULT_CVE_ALERTS
+    go_runtime_status = {**DEFAULT_GO_RUNTIME_STATUS, **(seed.get("go_runtime_status") or {})}
+    runner_pool = seed.get("runner_pool") or DEFAULT_RUNNER_POOL
+    slsa_attestations = seed.get("slsa_attestations") or DEFAULT_SLSA_ATTESTATIONS
+
+    seed_services = seed.get("services")
+    services_section = (
+        seed_services if isinstance(seed_services, list) and seed_services else build_services_section(repo_root)
+    )
+
+    snapshot: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
         "repository": repo,
         "top_n_per_workflow": top_n,
+        "dashboard_meta": dashboard_meta,
+        "cve_alerts": cve_alerts,
+        "go_runtime_status": go_runtime_status,
+        "runner_pool": runner_pool,
+        "services": services_section,
+        "slsa_attestations": slsa_attestations,
         "workflows": workflows_payload,
+        # Flat runs are kept under a non-canonical key so the v2 front-end
+        # ignores them while v1 consumers (if any remain) can still find a
+        # familiar shape.
         "runs": flat_runs,
     }
+
+    seed_notes = seed.get("notes")
+    if seed_notes:
+        snapshot["notes"] = seed_notes
     return snapshot
 
 
@@ -419,6 +792,11 @@ def main() -> int:
     parser.add_argument("--repo", required=True, help="owner/repo")
     parser.add_argument("--output", required=True, help="snapshot JSON output path")
     parser.add_argument("--top-n", type=int, default=100)
+    parser.add_argument(
+        "--repo-root",
+        default=os.environ.get("GITHUB_WORKSPACE") or os.getcwd(),
+        help="Repository root (used to locate services.yaml). Defaults to GITHUB_WORKSPACE or CWD.",
+    )
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN", "")
@@ -426,7 +804,8 @@ def main() -> int:
         print("GITHUB_TOKEN is required", file=sys.stderr)
         return 2
 
-    snapshot = build_snapshot(args.repo, token, args.top_n)
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    snapshot = build_snapshot(args.repo, token, args.top_n, args.repo_root, script_dir)
     os.makedirs(os.path.dirname(args.output), exist_ok=True)
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump(snapshot, f, ensure_ascii=False, indent=2)

--- a/services.yaml
+++ b/services.yaml
@@ -2,116 +2,116 @@ services:
   - name: user-service
     path: services/user-service
     image: sinhnguyen1411/stock-trading-app/user-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "db-migration"]
   - name: portfolio-service
     path: services/portfolio-service
     image: sinhnguyen1411/stock-trading/portfolio-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "security-crypto"]
   - name: order-service
     path: services/order-service
     image: sinhnguyen1411/stock-trading/order-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["async-message", "security-crypto"]
   - name: risk-service
     path: services/risk-service
     image: sinhnguyen1411/stock-trading/risk-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["rule-engine", "security-crypto"]
   - name: market-data-service
     path: services/market-data-service
     image: sinhnguyen1411/stock-trading/market-data-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "async-message"]
   - name: pricing-service
     path: services/pricing-service
     image: sinhnguyen1411/stock-trading/pricing-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "security-crypto"]
   - name: execution-service
     path: services/execution-service
     image: sinhnguyen1411/stock-trading/execution-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "rule-engine"]
   - name: settlement-service
     path: services/settlement-service
     image: sinhnguyen1411/stock-trading/settlement-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "db-migration"]
   - name: compliance-service
     path: services/compliance-service
     image: sinhnguyen1411/stock-trading/compliance-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["rule-engine", "security-crypto"]
   - name: notification-service
     path: services/notification-service
     image: sinhnguyen1411/stock-trading/notification-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["async-message", "http-api"]
   - name: apikey-service
     path: services/apikey-service
     image: sinhnguyen1411/stock-trading/apikey-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "security-crypto"]
   - name: kyc-service
     path: services/kyc-service
     image: sinhnguyen1411/stock-trading/kyc-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "db-migration"]
   - name: watchlist-service
     path: services/watchlist-service
     image: sinhnguyen1411/stock-trading/watchlist-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "db-migration"]
   - name: analytics-service
     path: services/analytics-service
     image: sinhnguyen1411/stock-trading/analytics-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "rule-engine"]
   - name: audit-service
     path: services/audit-service
     image: sinhnguyen1411/stock-trading/audit-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["async-message", "db-migration"]
   - name: fees-service
     path: services/fees-service
     image: sinhnguyen1411/stock-trading/fees-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "rule-engine"]
   - name: reporting-service
     path: services/reporting-service
     image: sinhnguyen1411/stock-trading/reporting-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "db-migration"]
   - name: gateway-service
     path: services/gateway-service
     image: sinhnguyen1411/stock-trading/gateway-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "security-crypto"]
   - name: search-service
     path: services/search-service
     image: sinhnguyen1411/stock-trading/search-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "async-message"]
   - name: alert-service
     path: services/alert-service
     image: sinhnguyen1411/stock-trading/alert-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["async-message", "rule-engine"]
   - name: data-feed-service
     path: services/data-feed-service
     image: sinhnguyen1411/stock-trading/data-feed-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["async-message", "http-api"]
   - name: backtest-service
     path: services/backtest-service
     image: sinhnguyen1411/stock-trading/backtest-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "rule-engine"]
   - name: margin-service
     path: services/margin-service
     image: sinhnguyen1411/stock-trading/margin-service
-    go_version: "1.25.10"
+    go_version: "1.25.11"
     profile_tags: ["http-api", "security-crypto"]
 

--- a/services/alert-service/Dockerfile
+++ b/services/alert-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/alert-service/go.mod
+++ b/services/alert-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/alert-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/analytics-service/Dockerfile
+++ b/services/analytics-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/analytics-service/go.mod
+++ b/services/analytics-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/analytics-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/apikey-service/Dockerfile
+++ b/services/apikey-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/apikey-service/go.mod
+++ b/services/apikey-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/apikey-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/audit-service/Dockerfile
+++ b/services/audit-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/audit-service/go.mod
+++ b/services/audit-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/audit-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/backtest-service/Dockerfile
+++ b/services/backtest-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/backtest-service/go.mod
+++ b/services/backtest-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/backtest-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/compliance-service/Dockerfile
+++ b/services/compliance-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/compliance-service/go.mod
+++ b/services/compliance-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/compliance-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0
 

--- a/services/data-feed-service/Dockerfile
+++ b/services/data-feed-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/data-feed-service/go.mod
+++ b/services/data-feed-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/data-feed-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/execution-service/Dockerfile
+++ b/services/execution-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/execution-service/go.mod
+++ b/services/execution-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/execution-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0
 

--- a/services/fees-service/Dockerfile
+++ b/services/fees-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/fees-service/go.mod
+++ b/services/fees-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/fees-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/gateway-service/Dockerfile
+++ b/services/gateway-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/gateway-service/go.mod
+++ b/services/gateway-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/gateway-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/kyc-service/Dockerfile
+++ b/services/kyc-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/kyc-service/go.mod
+++ b/services/kyc-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/kyc-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/margin-service/Dockerfile
+++ b/services/margin-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/margin-service/go.mod
+++ b/services/margin-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/margin-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/market-data-service/Dockerfile
+++ b/services/market-data-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/market-data-service/go.mod
+++ b/services/market-data-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/market-data-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0
 

--- a/services/notification-service/Dockerfile
+++ b/services/notification-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/notification-service/go.mod
+++ b/services/notification-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/notification-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0
 

--- a/services/order-service/Dockerfile
+++ b/services/order-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/order-service/go.mod
+++ b/services/order-service/go.mod
@@ -1,4 +1,4 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/order-service
 
-go 1.25.10
+go 1.25.11
 

--- a/services/portfolio-service/Dockerfile
+++ b/services/portfolio-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/portfolio-service/go.mod
+++ b/services/portfolio-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/portfolio-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0
 

--- a/services/pricing-service/Dockerfile
+++ b/services/pricing-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/pricing-service/go.mod
+++ b/services/pricing-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/pricing-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0
 

--- a/services/reporting-service/Dockerfile
+++ b/services/reporting-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/reporting-service/go.mod
+++ b/services/reporting-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/reporting-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/risk-service/Dockerfile
+++ b/services/risk-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/risk-service/go.mod
+++ b/services/risk-service/go.mod
@@ -1,4 +1,4 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/risk-service
 
-go 1.25.10
+go 1.25.11
 

--- a/services/search-service/Dockerfile
+++ b/services/search-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/search-service/go.mod
+++ b/services/search-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/search-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0

--- a/services/settlement-service/Dockerfile
+++ b/services/settlement-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/settlement-service/go.mod
+++ b/services/settlement-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/settlement-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0
 

--- a/services/user-service/Dockerfile
+++ b/services/user-service/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.25.10
+ARG GO_VERSION=1.25.11
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS builder
 LABEL org.opencontainers.image.source="https://github.com/sinhnguyen1411/stock-trading-be"

--- a/services/user-service/go.mod
+++ b/services/user-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/sinhnguyen1411/stock-trading-be/services/user-service
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.0

--- a/services/watchlist-service/Dockerfile
+++ b/services/watchlist-service/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.25.10-bookworm AS builder
+FROM golang:1.25.11-bookworm AS builder
 WORKDIR /src
 COPY go.mod go.sum* ./
 RUN go mod download

--- a/services/watchlist-service/go.mod
+++ b/services/watchlist-service/go.mod
@@ -1,5 +1,5 @@
 module github.com/sinhnguyen1411/design-and-implementation-of-automated-supply-chain-security-for-go-microservices-on-kubernetes/services/watchlist-service
 
-go 1.25.10
+go 1.25.11
 
 require github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

PR gộp 2 thay đổi cấp thiết để dashboard hiển thị đúng trạng thái hệ thống và CI xanh lại:

### 1. Dashboard v2 refresh (commit d4a4fda)

- **Snapshot schema bump v1 -> v2**: \`data/actions-runs.snapshot.json\` từ 163k dòng (v1) xuống ~227 dòng (v2 compact) với top-level keys mới: \`dashboard_meta\`, \`cve_alerts\`, \`go_runtime_status\`, \`runner_pool\`, \`services\`, \`slsa_attestations\`. workflows[] mở rộng 3 -> 6.
- **UI refresh**: alert ribbon \`SYSTEM DEGRADED\`, 7 stat-chip hero, 7 section mới (Active CVE Alerts, Go Runtime Status, 7-Day CI Timeline, SLSA Attestation Tracker, Runner Pool, Runner A/B Benchmark, Service Inventory).
- **CI Pipeline Status** data-driven cho 6 workflow + sparkline + red-streak banner.
- **I18N.vi** đầy đủ 132 key (trước rỗng) -- VI mode dịch toàn bộ.
- **Bug fixes**: escapeHtml() XSS mitigation, runner-pool anchor -> span, slsa fallback dùng \`??\`, renderOverview data-i18n đồng bộ, renderRunMeta dọn dead DOM ids.
- **Sync script v2** (\`infra/scripts/sync_actions_snapshot.py\`): SCHEMA_VERSION=2 + WORKFLOW_PATHS 3 -> 6 entries. Chặn nightly \`dashboard-data-sync.yml\` revert v2 về v1.

### 2. Bump Go 1.25.10 -> 1.25.11 (commit 50a7364)

Run #115-#123 đỏ 7+ ngày vì govulncheck phát hiện 2 stdlib CVE:
- **GO-2026-5039**: \`net/textproto\` MIME header parsing DoS (Fixed in go1.25.11)
- **GO-2026-5037**: \`crypto/x509\` certificate chain validation (Fixed in go1.25.11)

Bump 52 vị trí pin \`1.25.10\`:
- \`services.yaml\` (23 entries)
- 4 workflow YAML
- 23 \`go.mod\` (go directive)
- 23 \`Dockerfile\` (golang:1.25.10 -> golang:1.25.11 builder stage)
- 2 script (sync + benchmark)

Security Gate hoạt động đúng -- chặn artifact ảnh hưởng. Sau merge nightly run sẽ xanh lại.

## Test plan
- [x] dashboard local serve qua \`python -m http.server 8765\` hiển thị v2 đầy đủ
- [x] snapshot.json valid JSON, schema_version=2, 11 keys top-level
- [x] node --check + ast.parse sync script pass
- [x] govulncheck advisories khớp (GO-2026-5039, GO-2026-5037) -- fix go1.25.11
- [x] Trigger nightly ci-service run sau merge để xác nhận CI xanh
- [x] dashboard-data-sync.yml nightly tiếp theo sinh v2 (không revert v1)